### PR TITLE
Add forgot password route

### DIFF
--- a/lib/core/router/nav_routes.dart
+++ b/lib/core/router/nav_routes.dart
@@ -3,6 +3,7 @@ import 'package:cherry_mvp/features/register/registerpage.dart';
 import 'package:cherry_mvp/features/home/homepage.dart';
 import 'package:cherry_mvp/features/login/loginpage.dart';
 import 'package:cherry_mvp/features/welcome/welcome_page.dart';
+import 'package:cherry_mvp/features/password_flow/not_you_page/not_you_page.dart';
 
 
 class AppRoutes {
@@ -22,6 +23,8 @@ class AppRoutes {
         return MaterialPageRoute(builder: (_) => const LoginPage());
       case register:
         return MaterialPageRoute(builder: (_) => RegisterPage());
+      case forgotPassword:
+        return MaterialPageRoute(builder: (_) => NotYouPage());
       case home:
         return MaterialPageRoute(builder: (_) => HomePage());
       default:

--- a/lib/features/login/widgets/loginform.dart
+++ b/lib/features/login/widgets/loginform.dart
@@ -119,7 +119,7 @@ class LoginFormState extends State<LoginForm> {
             // Forgot Password
             GestureDetector(
               onTap: () {
-               navigator.replaceWith(AppRoutes.home);
+               navigator.replaceWith(AppRoutes.forgotPassword);
               },
               child: Center(
                 child: Text(AppStrings.forgotPassword,


### PR DESCRIPTION
## Summary
- wire up forgot password screen in router
- navigate to forgot password page from login form

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842237461388331b5f369e13c8fa168