### PR TITLE
feat: store dummy order in Firestore on checkout

### DIFF
--- a/lib/features/checkout/checkout_page.dart
+++ b/lib/features/checkout/checkout_page.dart
@@ -98,14 +98,14 @@ class _CheckoutPageState extends State<CheckoutPage> {
               height: 56,
               width: double.infinity,
               child: FilledButton(
-                onPressed: () {
-                  if (context.read<CheckoutViewModel>().deliveryChoice ==
-                          "pickup" &&
-                      context.read<CheckoutViewModel>().selectedInpost !=
-                          null) {
-                    Provider.of<CheckoutViewModel>(context, listen: false)
-                        .storeLockerInFirestore();
+                onPressed: () async {
+                  final checkoutViewModel = context.read<CheckoutViewModel>();
+                  if (checkoutViewModel.deliveryChoice == "pickup" &&
+                      checkoutViewModel.selectedInpost != null) {
+                    await checkoutViewModel.storeLockerInFirestore();
                   }
+                  // Store dummy order in Firestore
+                  await checkoutViewModel.storeOrderInFirestore();
                   Navigator.pushReplacementNamed(
                       context, AppRoutes.checkoutComplete);
                 },

--- a/lib/features/checkout/checkout_repository.dart
+++ b/lib/features/checkout/checkout_repository.dart
@@ -9,6 +9,9 @@ abstract class ICheckoutRepository {
 
   Future<void> storeLockerInFirestore(InpostModel data);
 
+  /// Store a dummy order in Firestore
+  Future<void> storeOrderInFirestore(Map<String, dynamic> orderData);
+
   Future<Result<DocumentSnapshot>> fetchUserLocker();
 }
 
@@ -53,6 +56,18 @@ final class CheckoutRepository implements ICheckoutRepository {
     await _firestoreService.saveDocument(
         FirestoreConstants.orders, FirestoreConstants.pickup, lockerData,
         isOrder: true);
+  }
+
+  @override
+  Future<void> storeOrderInFirestore(Map<String, dynamic> orderData) async {
+    // Use a generated order ID (timestamp-based)
+    final orderId = DateTime.now().millisecondsSinceEpoch.toString();
+    await _firestoreService.saveDocument(
+      FirestoreConstants.orders,
+      orderId,
+      orderData,
+      isOrder: true,
+    );
   }
 
   @override

--- a/lib/features/checkout/checkout_view_model.dart
+++ b/lib/features/checkout/checkout_view_model.dart
@@ -1,3 +1,30 @@
+  /// Store a dummy order in Firestore
+  Future<void> storeOrderInFirestore() async {
+    final Map<String, dynamic> orderData = {
+      'items': basketItems
+          .map((item) => {
+                'id': item.id,
+                'name': item.name,
+                'price': item.price,
+                'image': item.image,
+              })
+          .toList(),
+      'shipping_address': {
+        'formatted_address': formattedShippingAddress,
+        ...shippingAddressComponents,
+        'latitude': _shippingAddress?.latitude,
+        'longitude': _shippingAddress?.longitude,
+      },
+      'totals': {
+        'item_total': itemTotal,
+        'security_fee': securityFee,
+        'postage': postage,
+        'total': total,
+      },
+      'created_at': DateTime.now().toIso8601String(),
+    };
+    await checkoutRepository.storeOrderInFirestore(orderData);
+  }
 import 'package:cherry_mvp/core/config/config.dart';
 import 'package:cherry_mvp/core/models/inpost_model.dart';
 import 'package:cherry_mvp/core/models/product.dart';


### PR DESCRIPTION
This PR implements dummy order creation in Firestore when a user completes checkout.\n- Stores product, shipping, and order details in Firestore\n- No payment or shipping integration yet (UI only)\n- Prepares for future order history display in profile\n\nCloses #order-simulation