### PR TITLE
feat(checkout): enforce payment method selection and prevent order wi…

### DIFF
--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -247,11 +247,11 @@ class AppStrings {
 
   // Payment Methods
   static const paymentMethodsTitle = 'Payment Methods';
-  static const paymentMethodsInfo =
-      'Your payment information will never be shared with the seller';
+  static const paymentMethodsInfo = 'Your payment information will never be shared with the seller';
+  static const paymentMethodsChoose = 'Choose a payment method';
   static const paymentMethodsCard = 'Card';
-  static const paymentMethodsGooglePay = 'Google Pay';
-  static const paymentMethodsApplePay = 'Apple Pay';
+  static const paymentMethodsGooglePay = 'Pay with Google Pay';
+  static const paymentMethodsApplePay = 'Pay with Apple Pay';
   static const paymentMethodsPay = 'Pay';
 
   // Purchase Security

--- a/lib/features/checkout/checkout_view_model.dart
+++ b/lib/features/checkout/checkout_view_model.dart
@@ -4,6 +4,7 @@ import 'package:cherry_mvp/core/models/inpost_model.dart';
 import 'package:cherry_mvp/core/models/product.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
 import 'package:cherry_mvp/features/checkout/checkout_repository.dart';
+import 'package:cherry_mvp/features/checkout/payment_type.dart';
 import 'package:cherry_mvp/features/checkout/widgets/shipping_address_widget.dart';
 import 'package:cherry_mvp/features/checkout/constants/address_constants.dart';
 import 'package:flutter/material.dart';
@@ -149,7 +150,16 @@ class CheckoutViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  PaymentType? selectedPaymentType;
   // Payment method methods
+  void setPaymentType(PaymentType type) {
+    selectedPaymentType = type;
+    notifyListeners();
+  }
+
+  PaymentType? getPaymentType () {
+    return selectedPaymentType;
+  }
 
   /// Sets whether a payment method has been configured
   void setPaymentMethod(bool hasPayment) {
@@ -470,4 +480,11 @@ class CheckoutViewModel extends ChangeNotifier {
     }
     notifyListeners();
   }
+
+  void resetCreateOrderStatus() {
+    _createOrderStatus = Status.uninitialized;
+    notifyListeners();
+  }
+
+  
 }

--- a/lib/features/checkout/payment_type.dart
+++ b/lib/features/checkout/payment_type.dart
@@ -1,5 +1,5 @@
 enum PaymentType {
   card,
-  google,
+  google ,
   apple,
 }

--- a/lib/features/checkout/widgets/delivery_options.dart
+++ b/lib/features/checkout/widgets/delivery_options.dart
@@ -33,6 +33,23 @@ class _DeliveryOptionsState extends State<DeliveryOptions> {
   final TextEditingController cityController = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final vm = context.read<CheckoutViewModel>();
+
+      if (vm.deliveryChoice!.isNotEmpty) {
+        setState(() {
+          _delivery = vm.deliveryChoice;
+          _deliverExpanded = _delivery == 'pickup' && vm.selectedInpost != null;
+        });
+      }
+    });
+  }
+
+
+  @override
   Widget build(BuildContext context) {
     final basket = context.read<CheckoutViewModel>();
     return SliverPadding(

--- a/lib/features/checkout/widgets/select_payment_type_bottom_sheet.dart
+++ b/lib/features/checkout/widgets/select_payment_type_bottom_sheet.dart
@@ -1,108 +1,140 @@
 import 'package:cherry_mvp/core/config/config.dart';
+import 'package:cherry_mvp/features/checkout/checkout_view_model.dart';
 import 'package:cherry_mvp/features/checkout/payment_type.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class SelectPaymentTypeBottomSheet extends StatefulWidget {
   const SelectPaymentTypeBottomSheet({super.key});
 
   @override
-  State<SelectPaymentTypeBottomSheet> createState() =>
-      _SelectPaymentTypeBottomSheetState();
+  State<SelectPaymentTypeBottomSheet> createState() =>   _SelectPaymentTypeBottomSheetState();
 }
 
-class _SelectPaymentTypeBottomSheetState
-    extends State<SelectPaymentTypeBottomSheet> {
+class _SelectPaymentTypeBottomSheetState extends State<SelectPaymentTypeBottomSheet> {
   PaymentType? _selected;
 
   @override
   Widget build(BuildContext context) {
-    return BottomSheet(
-      onClosing: () {},
-      shape: const BeveledRectangleBorder(),
-      builder: (context) => Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: 16,
-              vertical: 24,
-            ),
-            width: double.infinity,
-            child: Text(
-              AppStrings.paymentMethodsTitle,
-              style: Theme.of(context).textTheme.headlineSmall,
-            ),
-          ),
-          ListTile(
-            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-            title: Text(AppStrings.paymentMethodsInfo),
-            titleTextStyle: Theme.of(context).textTheme.bodySmall,
-            textColor: Theme.of(context).colorScheme.onSurfaceVariant,
-          ),
-          const Divider(height: 1),
-          ListTile(
-            leading: const Icon(Icons.credit_card),
-            title: Text(AppStrings.paymentMethodsCard),
-            trailing: Radio.adaptive(
-                value: PaymentType.card,
-                groupValue: _selected,
-                onChanged: (value) {
-                  setState(() => _selected = value);
-                }),
-            onTap: () => setState(() => _selected = PaymentType.card),
-          ),
-          const Divider(height: 1),
-          ListTile(
-            leading: Image.asset(
-              AppImages.paymentMethodsGoogleIcon,
-              width: 24,
-              height: 24,
-            ),
-            title: Text(AppStrings.paymentMethodsGooglePay),
-            trailing: Radio.adaptive(
-                value: PaymentType.google,
-                groupValue: _selected,
-                onChanged: (value) {
-                  setState(() => _selected = value);
-                }),
-            onTap: () => setState(() => _selected = PaymentType.google),
-          ),
-          const Divider(height: 1),
-          ListTile(
-            leading: Image.asset(
-              AppImages.paymentMethodsAppleIcon,
-              width: 24,
-              height: 24,
-            ),
-            title: Text(AppStrings.paymentMethodsApplePay),
-            trailing: Radio.adaptive(
-                value: PaymentType.apple,
-                groupValue: _selected,
-                onChanged: (value) {
-                  setState(() => _selected = value);
-                }),
-            onTap: () => setState(() => _selected = PaymentType.apple),
-          ),
-          const SizedBox(height: 32),
-          Container(
-            height: 48,
-            width: double.infinity,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: FilledButton(
-              style: FilledButton.styleFrom(
-                foregroundColor: Theme.of(context).colorScheme.surface,
-                backgroundColor: Theme.of(context).colorScheme.onSurface,
+    return Consumer<CheckoutViewModel>(
+      builder: (context, vm, _) {
+        final selected = vm.selectedPaymentType;
+    
+        return BottomSheet(
+          onClosing: () {},
+          shape: const BeveledRectangleBorder(),
+          builder: (context) => Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  color: AppColors.pinkBackground
+                ),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 10,
+                ),
+                width: double.infinity,
+                child: Text(
+                  AppStrings.paymentMethodsTitle,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
               ),
-              onPressed: _selected != null
-                  ? () => Navigator.pop(context, _selected)
-                  : null,
-              child: Text(AppStrings.paymentMethodsPay),
-            ),
-          ),
-          SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
-        ],
-      ),
+              ListTile(
+                contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+                title: Text(AppStrings.paymentMethodsInfo),
+                titleTextStyle: Theme.of(context).textTheme.labelSmall,
+                textColor: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+              Divider(height: 1, color: AppColors.grey,),
+
+              const SizedBox(height: 30,),
+              ListTile(
+                leading: const Icon(Icons.credit_card),
+                title: Text(AppStrings.paymentMethodsCard),
+                trailing: Radio<PaymentType>(
+                  value: PaymentType.card,   
+                  groupValue: vm.selectedPaymentType ,
+                  onChanged: (value) {
+                    vm.setPaymentType(value!);
+                    setState(() => _selected = value);
+                  },             
+                ),
+                onTap: () {
+                  vm.setPaymentType(PaymentType.card);
+                  _selected = PaymentType.card;
+                } 
+              ),
+              Divider(height: 1, color: AppColors.grey,),
+
+              // Google Pay
+              ListTile(
+                leading: Image.asset(
+                  AppImages.paymentMethodsGoogleIcon,
+                  width: 24,
+                  height: 24,
+                ),
+                title: Text(AppStrings.paymentMethodsGooglePay),
+                trailing: Radio<PaymentType>(
+                  value: PaymentType.google,
+                  groupValue: vm.selectedPaymentType ,
+                  onChanged: (value) {
+                    vm.setPaymentType(value!);
+                    setState(() => _selected = value);
+                  },
+                ),
+                onTap: () {
+                  vm.setPaymentType(PaymentType.google);
+                  _selected = PaymentType.google;
+                } 
+              ),
+              Divider(height: 1, color: AppColors.grey,),
+
+              // Apple Pay
+              ListTile(
+                leading: Image.asset(
+                  AppImages.paymentMethodsAppleIcon,
+                  width: 24,
+                  height: 24,
+                ),
+                title: Text(AppStrings.paymentMethodsApplePay),
+                trailing: Radio<PaymentType>(
+                  value: PaymentType.apple,
+                  groupValue: vm.selectedPaymentType ,
+                  onChanged: (value) {
+                    vm.setPaymentType(value!);
+                    setState(() => _selected = value);
+                  },
+                ),
+                onTap: () {
+                  vm.setPaymentType(PaymentType.apple);
+                  _selected = PaymentType.apple;
+                } 
+              ),
+              Divider(height: 1, color: AppColors.grey,),
+              const SizedBox(height: 32),
+
+              Container(
+                height: 48,
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: FilledButton(
+                  style: FilledButton.styleFrom(
+                    foregroundColor: Theme.of(context).colorScheme.surface,
+                    backgroundColor: Theme.of(context).colorScheme.onSurface,
+                  ),
+                  onPressed: _selected != null
+                      ? () => Navigator.pop(context, _selected)
+                      : null,
+                  child: Text(AppStrings.continueText),
+                ),
+              ),
+              SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
+            ],
+          )
+        );
+      }
     );
   }
 }


### PR DESCRIPTION
**What this PR does**

- Adds payment method selection to checkout
- Prevents placing an order without a selected payment method
- Fixes issue where order could auto-process on page rebuild
- Persists payment and delivery state when navigating away and back
- Aligns checkout flow with UI specs (payment via bottom sheet)

**Related issues**

- Closes #333 (Checkout: validate shipping address before allowing payment)
- Addresses payment method validation raised in checkout flow

**Notes**

- Stripe checkout couldn’t be fully tested locally due to ongoing Stripe setup issues
- Frontend validation and flow are in place; awaiting guidance on Stripe test setup or mock for MVP