### PR TITLE
feat: Implementation for delete account (#375)

### DIFF
--- a/lib/core/services/network/api_endpoints.dart
+++ b/lib/core/services/network/api_endpoints.dart
@@ -1,8 +1,4 @@
-
-
-
-
-  class ApiEndpoints {
+class ApiEndpoints {
     static const String products = '/products';
     static const String productsWithDetails = '/products/with-details';
 
@@ -15,4 +11,7 @@
     static const String charities = '/charities';
     static const String paymentIntent = '/payment/create-payment-intent';
     static const String createOrder = '/order/create';
+
+    // Auth related
+    static const String deleteAccount = '/auth/account';
   }

--- a/lib/features/settings/widgets/settings_footer.dart
+++ b/lib/features/settings/widgets/settings_footer.dart
@@ -1,8 +1,45 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:cherry_mvp/core/config/config.dart';
+import 'package:cherry_mvp/core/services/services.dart';
+import 'package:cherry_mvp/features/auth/auth_view_model.dart';
 
 class SettingsFooter extends StatelessWidget {
   const SettingsFooter({super.key});
+
+  Future<bool?> _showConfirmDialog(BuildContext context) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete account'),
+        content: const Text(
+            'Are you sure you want to delete your account? This action cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              'Delete',
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showLoadingDialog(BuildContext context) async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => const Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -10,7 +47,47 @@ class SettingsFooter extends StatelessWidget {
       ListTile(
         title: Text(AppStrings.deleteAccountText),
         textColor: Theme.of(context).colorScheme.primary,
-        onTap: () {},
+        onTap: () async {
+          final confirm = await _showConfirmDialog(context);
+          if (confirm != true) return;
+
+          // show loading
+          _showLoadingDialog(context);
+
+          try {
+            final apiService = Provider.of<ApiService>(context, listen: false);
+            final result = await apiService.delete(ApiEndpoints.deleteAccount);
+
+            // Temporary: pause here if a Dart debugger is attached
+            // import dart:developer as developer at top when using this in real debug
+            // developer.debugger();
+
+            // dismiss loading
+            if (context.mounted) Navigator.of(context).pop();
+
+            if (result.isSuccess) {
+              // On successful account deletion, log the user out and navigate to welcome
+              if (context.mounted) {
+                final authViewModel =
+                    Provider.of<AuthViewModel>(context, listen: false);
+                await authViewModel.logout(context);
+              }
+            } else {
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(result.error ?? 'Failed to delete account')),
+                );
+              }
+            }
+          } catch (e) {
+            if (context.mounted) Navigator.of(context).pop();
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Error: ${e.toString()}')),
+              );
+            }
+          }
+        },
       ),
       ListTile(
         title: Text(AppStrings.appName),


### PR DESCRIPTION
## Summary

Frontend changes to allow users to delete their accounts. The backend changes are here: https://github.com/Cherry-CIC/cherry-Backend/pull/19

<img width="425" height="865" alt="image" src="https://github.com/user-attachments/assets/ecae5967-ef12-4cef-9986-7878346ddf6a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account deletion functionality in settings with confirmation dialog, loading indicator during deletion, and automatic logout upon successful completion. Error notifications displayed on failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cherry-CIC/MVP/pull/377)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->