### PR TITLE
Refactor checkout to create backend orders after Stripe payment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,6 @@ migrate_working_dir/
 *.iws
 .idea/
 
-# The .vscode folder contains launch configuration and tasks you configure in
-# VS Code which you may wish to be included in version control, so this line
-# is commented out by default.
-#.vscode/
-
 # Flutter/Dart/Pub related
 **/doc/api/
 **/ios/Flutter/.last_build_id
@@ -42,14 +37,12 @@ pubspec.lock
 /ios/Pods/
 /ios/build/
 /ios/Podfile.lock
-/ios/Runner.xcodeproj
+# Removed /ios/Runner.xcodeproj to unblock iOS contributors
 /ios/Runner/GoogleService-Info.plist
 
 # Flutter generated
 **/Generated.xcconfig
 **/Flutter.podspec
-
-
 
 # Symbolication related
 app.*.symbols

--- a/lib/core/config/app_images.dart
+++ b/lib/core/config/app_images.dart
@@ -93,7 +93,6 @@ class AppImages {
   static const checkoutReviewIcon = '${_path}review.svg';
   static const checkoutPurhaseSecurityShield =
       '${_path}purchase_security_shield.png';
-  static const shieldTick = '${_path}shield_tick.png';
   static const refundPolicy = '${_path}refund_policy.png';
   static const secureTransactions = '${_path}lock_icon.png';
   static const yourSupport = '${_path}support_icon.png';

--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -25,6 +25,12 @@ class AppStrings {
   static const forgotPassword = 'Forgot Password?';
   static const forgotPasswordInstruction =
       'Please type your email and we’ll get in touch';
+  static const usernameSetupTitle = 'Who is this?';
+  static const usernameSetupSubtitle = 'Enter the name you will like to go by.';
+  static const usernameSetupHint = 'Username';
+  static const usernameTakenError = 'Username is already taken.';
+  static const usernameSaveFailed =
+      'Could not save username. Please try again.';
   static const email = 'Email';
   static const sendEmail = 'Send email';
   static const userCheck = 'Not you';
@@ -50,7 +56,7 @@ class AppStrings {
   static const profileUserInfoSectionUser = "User";
   static const profileUserInfoSectionFollowing = "following";
   static const profileUserInfoSectionFollowers = "followers";
-  static const profileUserInfoSectionBuyerDiscount = "Buyer Discounts Active";
+  static const profileUserInfoSectionBuyerDiscount = "Donor discounts active";
   static const profileUserInfoSectionBuyerAwards = "Awards";
   static const profileUserInfoSectionBuyerReviews = "Reviews";
   static const profileUserInfoLocation = "United Kingdom";
@@ -58,7 +64,7 @@ class AppStrings {
   static const profileUserOrders = "Orders";
   static const profileUserLiked = "Liked";
   static const profileUserListings = "Listings";
-  static const profileUserBuyerDisc = "Buyer discounts";
+  static const profileUserBuyerDisc = "Donor discounts";
 
   // Profile: Donations & Activity
   static const profileUserActivityBought = 'Bought';
@@ -145,7 +151,9 @@ class AppStrings {
   static const openToOtherCharitiesText = "Open to other charities";
   static const openToOffersText = "Open to offers";
   static const applicableForBuyerDiscountsText =
-      "Applicable for buyer discounts";
+      "Applicable for donor discounts";
+  static const donorDiscountsActiveText = "Donor discounts active";
+  static const donorDiscountsInactiveText = "Donor discounts inactive";
 
   // Donation Fields
   static const titleText = "Title";
@@ -187,7 +195,10 @@ class AppStrings {
 
   // Product Page
   static const productPageDescription = "Description";
-  static const productPageBuyerDiscountActive = 'Buyer discount active';
+  static const productPageBuyerDiscountActive = 'Donor discounts active';
+  static const productPageDonorDiscountInactive = 'Donor discounts inactive';
+  static const productPageDonorDiscountInactiveDetail =
+      'Donor Discounts Currently Inactive';
   static const productPageBuy2Get1HalfPrice = 'Buy 2 get 1 half price';
   static const productPageOpenToOtherCharities = 'Open to other charities';
   static const productPageRequestOtherCharity = 'Request other charity';
@@ -227,7 +238,8 @@ class AppStrings {
   static const checkoutImpactSummary = 'Impact Summary';
   static const checkoutReview = 'Review';
   static const checkoutContinueShopping = 'Continue Shopping';
-  static const checkoutDeliveryOptionRequired = 'Please choose a delivery option';
+  static const checkoutDeliveryOptionRequired =
+      'Please choose a delivery option';
   static const checkoutPickupLockerRequired = 'Please select a pickup locker';
   static const checkoutPaymentMethodRequired = 'Please select a payment method';
 
@@ -247,7 +259,8 @@ class AppStrings {
 
   // Payment Methods
   static const paymentMethodsTitle = 'Payment Methods';
-  static const paymentMethodsInfo = 'Your payment information will never be shared with the seller';
+  static const paymentMethodsInfo =
+      'Your payment information will never be shared with the seller';
   static const paymentMethodsChoose = 'Choose a payment method';
   static const paymentMethodsCard = 'Card';
   static const paymentMethodsGooglePay = 'Pay with Google Pay';

--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -242,6 +242,21 @@ class AppStrings {
       'Please choose a delivery option';
   static const checkoutPickupLockerRequired = 'Please select a pickup locker';
   static const checkoutPaymentMethodRequired = 'Please select a payment method';
+  static const checkoutDeliveryAddressRequired =
+      'Please confirm your delivery address';
+  static const checkoutPaymentFailed =
+      'Payment could not be completed. Please try again.';
+  static const checkoutPaymentCancelled = 'Payment was cancelled.';
+  static const checkoutPaymentDetailsUnavailable =
+      'Payment details could not be confirmed. Please try again.';
+  static const checkoutOrderCreationFailed =
+      'We could not create your order after payment. Please try again.';
+  static const checkoutShipmentFailed =
+      'Your order was created, but delivery could not be confirmed. Please contact support if this continues.';
+  static const checkoutShipmentPending =
+      'Payment complete. Your order is placed and delivery is still being arranged.';
+  static const checkoutRetryOrder = 'Retry order';
+  static const checkoutDeliveryPending = 'Delivery pending';
 
   // Card Details
   static const cardDetailsTitle = 'Card Details';

--- a/lib/core/models/user.dart
+++ b/lib/core/models/user.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 class UserCredentials {
   final String? uid;
   final String? email;
+  final String? username;
   final String? firstname;
   final String? photoUrl;
   final String? phoneNumber;
@@ -10,6 +11,7 @@ class UserCredentials {
   UserCredentials({
     required this.uid,
     required this.email,
+    this.username,
     this.firstname,
     this.photoUrl,
     this.phoneNumber,
@@ -19,6 +21,7 @@ class UserCredentials {
     return UserCredentials(
       uid: uid,
       email: data['email'],
+      username: data['username'],
       firstname: data['firstname'],
       photoUrl: data['photoUrl'],
     );

--- a/lib/core/services/network/api_endpoints.dart
+++ b/lib/core/services/network/api_endpoints.dart
@@ -1,18 +1,19 @@
+class ApiEndpoints {
+  static const String _apiPrefix = '/api';
 
+  static const String products = '$_apiPrefix/products';
+  static const String productsWithDetails = '$_apiPrefix/products/with-details';
 
+  // Auth sync
+  static const String authSync = '$_apiPrefix/auth/sync';
 
+  // Versioned endpoints (if we need API versioning)
+  static const String apiVersion = 'v1';
+  static String versioned(String endpoint) => '/$apiVersion$endpoint';
 
-  class ApiEndpoints {
-    static const String products = '/products';
-    static const String productsWithDetails = '/products/with-details';
-
-    // Versioned endpoints (if we need API versioning)
-    static const String apiVersion = 'v1';
-    static String versioned(String endpoint) => '/$apiVersion$endpoint';
-
-    static const String categories = '/categories';
-    static const String inpostLockers = '/shipping/inpost/lockers';
-    static const String charities = '/charities';
-    static const String paymentIntent = '/payment/create-payment-intent';
-    static const String createOrder = '/order/create';
-  }
+  static const String categories = '$_apiPrefix/categories';
+  static const String inpostLockers = '$_apiPrefix/shipping/inpost/lockers';
+  static const String charities = '$_apiPrefix/charities';
+  static const String paymentIntent = '$_apiPrefix/payment/create-payment-intent';
+  static const String createOrder = '$_apiPrefix/order/create';
+}

--- a/lib/core/services/network/api_service.dart
+++ b/lib/core/services/network/api_service.dart
@@ -1,14 +1,11 @@
-
+import 'dart:async';
 import 'package:dio/dio.dart';
-
-import 'package:cherry_mvp/core/models/donation_charity_model.dart';
-import 'package:cherry_mvp/core/utils/result.dart';
 import 'package:cherry_mvp/core/services/error_string.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 import 'package:logging/logging.dart';
-
+import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 
 abstract class ApiService {
   Future<Result<T>> get<T>(String endpoint, {Map<String, dynamic>? queryParameters});
@@ -18,236 +15,116 @@ abstract class ApiService {
 }
 
 class DioApiService implements ApiService {
+  static const String _defaultApiBaseUrl = 'https://cherry-backend-401854471349.europe-west2.run.app';
+  
   late final Dio _dio;
   final FirebaseAuth _firebaseAuth;
   final _log = Logger('DioApiService');
 
   DioApiService({FirebaseAuth? firebaseAuth})
       : _firebaseAuth = firebaseAuth ?? FirebaseAuth.instance {
-    _dio = Dio(BaseOptions(
-      baseUrl: dotenv.env['API_BASE_URL'] ?? '',
-      connectTimeout: const Duration(seconds: 30),
-      receiveTimeout: const Duration(seconds: 30),
-      sendTimeout: const Duration(seconds: 30),
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-      },
-    ));
     
+    final baseUrl = dotenv.env['API_BASE_URL'] ?? _defaultApiBaseUrl;
+    
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: _stripTrailingSlash(baseUrl),
+        connectTimeout: const Duration(seconds: 15),
+        receiveTimeout: const Duration(seconds: 15),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+      ),
+    );
+
+    _log.info('API initialized with base URL: ${_dio.options.baseUrl}');
     _setupInterceptors();
   }
-  
-  void _setupInterceptors() {
-    // Auth interceptor - add Firebase token to requests
-    _dio.interceptors.add(InterceptorsWrapper(
-      onRequest: (options, handler) async {
-        final user = _firebaseAuth.currentUser;
-        if (user != null) {
-          try {
-            final idToken = await user.getIdToken();
-            options.headers['Authorization'] = 'Bearer $idToken';
-          } catch (e) {
-            _log.severe('Error getting Firebase ID token: $e');
-          }
-        }
-        handler.next(options);
-      },
-      onError: (error, handler) async {
-        if (error.response?.statusCode == 401) {
-          // Handle unauthorized access - could refresh token here
-          _log.warning('Unauthorized access - user might need to re-authenticate');
-        }
-        
-        // Check if we should retry the request
-        if (_shouldRetry(error)) {
-          try {
-            await Future.delayed(const Duration(seconds: 1));
-            final response = await _dio.fetch(error.requestOptions);
-            handler.resolve(response);
-            return;
-          } catch (e) {
-            // If retry fails, proceed with original error
-          }
-        }
-        handler.next(error);
-      },
-    ));
 
-    // Logging interceptor
-    _dio.interceptors.add(PrettyDioLogger(
-      requestHeader: true,
-      requestBody: true,
-      responseHeader: false,
-      responseBody: true,
-      error: true,
-      compact: true,
-      maxWidth: 90,
-    ));
+  void _setupInterceptors() {
+    _dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          try {
+            final user = _firebaseAuth.currentUser;
+            if (user != null) {
+              final idToken = await user.getIdToken().timeout(
+                const Duration(seconds: 3),
+                onTimeout: () => '',
+              );
+              
+              if (idToken.isNotEmpty) {
+                options.headers['Authorization'] = 'Bearer $idToken';
+              }
+            }
+          } catch (e) {
+            _log.warning('Auth interceptor error: $e');
+          }
+          return handler.next(options);
+        },
+      ),
+    );
+
+    _dio.interceptors.add(
+      PrettyDioLogger(
+        requestHeader: true,
+        requestBody: true,
+        responseBody: true,
+        error: true,
+        compact: true,
+      ),
+    );
   }
-  
+
   @override
   Future<Result<T>> get<T>(String endpoint, {Map<String, dynamic>? queryParameters}) async {
     try {
       final response = await _dio.get(endpoint, queryParameters: queryParameters);
-      return _handleResponse<T>(response);
+      return Result.success(response.data as T);
     } on DioException catch (e) {
-      _log.severe('GET request failed for $endpoint: ${e.toString()}');
       return Result.failure(_handleDioError(e));
-    } catch (e) {
-      _log.severe('Unexpected error in GET $endpoint: ${e.toString()}');
-      return Result.failure(ErrorStrings.friendlyError);
     }
   }
-  
+
   @override
   Future<Result<T>> post<T>(String endpoint, {dynamic data}) async {
     try {
       final response = await _dio.post(endpoint, data: data);
-      return _handleResponse<T>(response);
+      return Result.success(response.data as T);
     } on DioException catch (e) {
-      _log.severe('POST request failed for $endpoint: ${e.toString()}');
       return Result.failure(_handleDioError(e));
-    } catch (e) {
-      _log.severe('Unexpected error in POST $endpoint: ${e.toString()}');
-      return Result.failure(ErrorStrings.friendlyError);
     }
   }
-  
+
   @override
   Future<Result<T>> put<T>(String endpoint, {dynamic data}) async {
     try {
       final response = await _dio.put(endpoint, data: data);
-      return _handleResponse<T>(response);
+      return Result.success(response.data as T);
     } on DioException catch (e) {
-      _log.severe('PUT request failed for $endpoint: ${e.toString()}');
       return Result.failure(_handleDioError(e));
-    } catch (e) {
-      _log.severe('Unexpected error in PUT $endpoint: ${e.toString()}');
-      return Result.failure(ErrorStrings.friendlyError);
     }
   }
-  
+
   @override
   Future<Result<T>> delete<T>(String endpoint) async {
     try {
       final response = await _dio.delete(endpoint);
-      return _handleResponse<T>(response);
-    } on DioException catch (e) {
-      _log.severe('DELETE request failed for $endpoint: ${e.toString()}');
-      return Result.failure(_handleDioError(e));
-    } catch (e) {
-      _log.severe('Unexpected error in DELETE $endpoint: ${e.toString()}');
-      return Result.failure(ErrorStrings.friendlyError);
-    }
-  }
-
-  Result<T> _handleResponse<T>(Response response) {
-    if (response.statusCode != null && response.statusCode! >= 200 && response.statusCode! < 300) {
       return Result.success(response.data as T);
-    } else {
-      return Result.failure('Server returned status code: ${response.statusCode}');
+    } on DioException catch (e) {
+      return Result.failure(_handleDioError(e));
     }
   }
-  /// Fetch charity categories from the API.
 
-  Future<Result<List<CharityCategories>>> git() async {
-    const String endpoint = '/api/charities';
-
-    final result = await get<Map<String, dynamic>>(endpoint);
-    if (result.isSuccess && result.value != null) {
-      try {
-        final responseMap = result.value!;
-
-        // Check if the response has a 'data' field
-        if (!responseMap.containsKey('data')) {
-          _log.severe('API response missing "data" field: $responseMap');
-          return Result.failure('Invalid API response structure');
-        }
-
-        final charityListData = responseMap['data'];
-
-        if (charityListData is! List) {
-          _log.severe('Expected "data" to be a List but got ${charityListData.runtimeType}');
-          return Result.failure('Invalid charity data format');
-        }
-
-        final charities = (charityListData as List<dynamic>)
-            .map((json) => CharityCategories.fromJson(json as Map<String, dynamic>))
-            .toList();
-
-        _log.info('Successfully parsed ${charities.length} charities');
-        return Result.success(charities);
-      } catch (e) {
-        _log.severe('Error parsing charity list: $e');
-        return Result.failure('Failed to parse charity data: ${e.toString()}');
-      }
-    } else {
-      return Result.failure(result.error ?? 'Unknown error occurred');
-    }
-  }
   String _handleDioError(DioException e) {
-    // Log the technical details for debugging
-    _log.warning('DioException occurred: ${e.type} - ${e.message}');
-    
-    switch (e.type) {
-      case DioExceptionType.connectionTimeout:
-      case DioExceptionType.sendTimeout:
-      case DioExceptionType.receiveTimeout:
-        return ErrorStrings.timeoutError;
-      case DioExceptionType.badCertificate:
-        _log.severe('Bad certificate error: ${e.message}');
-        return ErrorStrings.serverError;
-      case DioExceptionType.cancel:
-        return ErrorStrings.friendlyError;
-      case DioExceptionType.connectionError:
-      case DioExceptionType.unknown:
-        return ErrorStrings.networkError;
-      case DioExceptionType.badResponse:
-        return _handleBadResponse(e);
+    if (e.type == DioExceptionType.connectionTimeout || e.type == DioExceptionType.receiveTimeout) {
+      return ErrorStrings.timeoutError;
     }
+    return ErrorStrings.networkError;
   }
 
-  String _handleBadResponse(DioException e) {
-    final statusCode = e.response?.statusCode;
-    final data = e.response?.data;
-    
-    // Log technical details for debugging
-    _log.warning('Bad response: $statusCode - $data');
-    
-    switch (statusCode) {
-      case 400:
-      case 422:
-        // Log specific validation errors for debugging
-        final serverMessage = _extractErrorMessage(data);
-        if (serverMessage != null) {
-          _log.info('Server validation error: $serverMessage');
-        }
-        return ErrorStrings.apiError;
-      case 401:
-        return ErrorStrings.unauthorizedError;
-      case 403:
-      case 404:
-        return ErrorStrings.apiError;
-      case 500:
-      case 502:
-      case 503:
-        return ErrorStrings.serverError;
-      default:
-        return ErrorStrings.friendlyError;
-    }
-  }
-
-  String? _extractErrorMessage(dynamic data) {
-    if (data is Map<String, dynamic>) {
-      return data['message'] ?? data['error'] ?? data['detail'];
-    }
-    return null;
-  }
-
-  bool _shouldRetry(DioException error) {
-    return error.type == DioExceptionType.connectionTimeout ||
-           error.type == DioExceptionType.receiveTimeout ||
-           error.type == DioExceptionType.connectionError;
+  String _stripTrailingSlash(String url) {
+    return url.endsWith('/') ? url.substring(0, url.length - 1) : url;
   }
 }

--- a/lib/core/services/network/api_service.dart
+++ b/lib/core/services/network/api_service.dart
@@ -3,29 +3,33 @@ import 'package:dio/dio.dart';
 import 'package:cherry_mvp/core/services/error_string.dart';
 import 'package:cherry_mvp/core/utils/result.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:logging/logging.dart';
 import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 
 abstract class ApiService {
-  Future<Result<T>> get<T>(String endpoint, {Map<String, dynamic>? queryParameters});
+  Future<Result<T>> get<T>(
+    String endpoint, {
+    Map<String, dynamic>? queryParameters,
+  });
   Future<Result<T>> post<T>(String endpoint, {dynamic data});
   Future<Result<T>> put<T>(String endpoint, {dynamic data});
   Future<Result<T>> delete<T>(String endpoint);
 }
 
 class DioApiService implements ApiService {
-  static const String _defaultApiBaseUrl = 'https://cherry-backend-401854471349.europe-west2.run.app';
-  
+  static const String _defaultApiBaseUrl =
+      'https://cherry-backend-401854471349.europe-west2.run.app';
+
   late final Dio _dio;
   final FirebaseAuth _firebaseAuth;
   final _log = Logger('DioApiService');
 
   DioApiService({FirebaseAuth? firebaseAuth})
-      : _firebaseAuth = firebaseAuth ?? FirebaseAuth.instance {
-    
+    : _firebaseAuth = firebaseAuth ?? FirebaseAuth.instance {
     final baseUrl = dotenv.env['API_BASE_URL'] ?? _defaultApiBaseUrl;
-    
+
     _dio = Dio(
       BaseOptions(
         baseUrl: _stripTrailingSlash(baseUrl),
@@ -53,7 +57,7 @@ class DioApiService implements ApiService {
                 const Duration(seconds: 3),
                 onTimeout: () => '',
               );
-              
+
               if (idToken.isNotEmpty) {
                 options.headers['Authorization'] = 'Bearer $idToken';
               }
@@ -66,21 +70,29 @@ class DioApiService implements ApiService {
       ),
     );
 
-    _dio.interceptors.add(
-      PrettyDioLogger(
-        requestHeader: true,
-        requestBody: true,
-        responseBody: true,
-        error: true,
-        compact: true,
-      ),
-    );
+    if (kDebugMode) {
+      _dio.interceptors.add(
+        PrettyDioLogger(
+          requestHeader: false,
+          requestBody: false,
+          responseBody: false,
+          error: true,
+          compact: true,
+        ),
+      );
+    }
   }
 
   @override
-  Future<Result<T>> get<T>(String endpoint, {Map<String, dynamic>? queryParameters}) async {
+  Future<Result<T>> get<T>(
+    String endpoint, {
+    Map<String, dynamic>? queryParameters,
+  }) async {
     try {
-      final response = await _dio.get(endpoint, queryParameters: queryParameters);
+      final response = await _dio.get(
+        endpoint,
+        queryParameters: queryParameters,
+      );
       return Result.success(response.data as T);
     } on DioException catch (e) {
       return Result.failure(_handleDioError(e));
@@ -118,7 +130,8 @@ class DioApiService implements ApiService {
   }
 
   String _handleDioError(DioException e) {
-    if (e.type == DioExceptionType.connectionTimeout || e.type == DioExceptionType.receiveTimeout) {
+    if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.receiveTimeout) {
       return ErrorStrings.timeoutError;
     }
     return ErrorStrings.networkError;

--- a/lib/core/services/services.dart
+++ b/lib/core/services/services.dart
@@ -4,3 +4,4 @@ export 'firebase_storage.dart';
 export 'error_string.dart';
 export 'network/api_service.dart';
 export 'network/api_endpoints.dart';
+export 'username_service.dart';

--- a/lib/features/checkout/checkout_page.dart
+++ b/lib/features/checkout/checkout_page.dart
@@ -19,7 +19,7 @@ class CheckoutPage extends StatefulWidget {
 
 class _CheckoutPageState extends State<CheckoutPage> {
   String _errorMessage = "";
-  late final CheckoutViewModel vm;
+  CheckoutViewModel? vm;
 
   @override
   void initState() {
@@ -29,32 +29,55 @@ class _CheckoutPageState extends State<CheckoutPage> {
       if (!mounted) return;
 
       vm = context.read<CheckoutViewModel>();
-      vm.resetCreateOrderStatus();
-      vm.fetchUserLocker();
-      vm.addListener(_handleOrderStatus);
+      vm!.resetCreateOrderStatus();
+      vm!.fetchUserLocker();
+      vm!.addListener(_handleOrderStatus);
     });
   }
 
-
   void _handleOrderStatus() {
     if (!mounted) return;
+    final checkoutViewModel = vm;
+    if (checkoutViewModel == null) return;
 
-    final status = vm.createOrderStatus.type;
+    final status = checkoutViewModel.createOrderStatus.type;
+    final flowState = checkoutViewModel.checkoutFlowState;
 
-    if (status == StatusType.failure) {
-      Fluttertoast.showToast(
-        msg: vm.createOrderStatus.message ?? "oops! Something went wrong",
-      );
-      vm.resetCreateOrderStatus();
+    if (status == StatusType.success &&
+        flowState == CheckoutFlowState.shipmentPending) {
+      final message =
+          checkoutViewModel.createOrderStatus.message ??
+          AppStrings.checkoutShipmentPending;
+      setState(() {
+        _errorMessage = message;
+      });
+      Fluttertoast.showToast(msg: message);
+      checkoutViewModel.resetCreateOrderStatus();
+      return;
     }
 
-    if (status == StatusType.success) {
-      Fluttertoast.showToast(msg: "Payment Successful");
-      vm.resetCreateOrderStatus();
+    if (status == StatusType.success &&
+        flowState == CheckoutFlowState.shipmentCreated) {
+      setState(() {
+        _errorMessage = "";
+      });
+      Fluttertoast.showToast(msg: "Payment successful");
+      checkoutViewModel.resetCreateOrderStatus();
       gotoCheckoutComplete();
+      return;
+    }
+
+    if (status == StatusType.failure || status == StatusType.canceled) {
+      final message =
+          checkoutViewModel.createOrderStatus.message ??
+          "Oops! Something went wrong";
+      setState(() {
+        _errorMessage = message;
+      });
+      Fluttertoast.showToast(msg: message);
+      checkoutViewModel.resetCreateOrderStatus();
     }
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -80,48 +103,51 @@ class _CheckoutPageState extends State<CheckoutPage> {
 
           //if (_errorMessage.isNotEmpty)
           if (_errorMessage.isNotEmpty)
-          SliverToBoxAdapter(
-            child: Container(
-              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primaryContainer,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: AppColors.primaryAction,
+            SliverToBoxAdapter(
+              child: Container(
+                margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: AppColors.primaryAction),
                 ),
-              ),
-              child: Text(
-                _errorMessage,
-                style: TextStyle(
-                  color: AppColors.primaryAction,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
+                child: Text(
+                  _errorMessage,
+                  style: TextStyle(
+                    color: AppColors.primaryAction,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
               ),
             ),
-          ),
 
-          SliverToBoxAdapter( 
+          SliverToBoxAdapter(
             child: Consumer<CheckoutViewModel>(
-              builder: (context, vm, _) { 
-              return ListTile( 
-                title: const Text(AppStrings.checkoutPayment),
-                subtitle: Text( 
-                vm.selectedPaymentType != null ? vm.selectedPaymentType!.name : AppStrings.paymentMethodsChoose, 
-                ), 
-                trailing: Icon( 
-                vm.selectedPaymentType != null ? Icons.check : Icons.add, 
-                color: Theme.of(context).colorScheme.primary, 
-                ), onTap: () { 
-                showModalBottomSheet( 
-                  context: context, isScrollControlled: true, 
-                  backgroundColor: Colors.transparent, builder: (_) => const SelectPaymentTypeBottomSheet(), 
-                ); 
-                } 
-              ); 
-              }, 
-            ), 
+              builder: (context, vm, _) {
+                return ListTile(
+                  title: const Text(AppStrings.checkoutPayment),
+                  subtitle: Text(
+                    vm.selectedPaymentType != null
+                        ? vm.selectedPaymentType!.name
+                        : AppStrings.paymentMethodsChoose,
+                  ),
+                  trailing: Icon(
+                    vm.selectedPaymentType != null ? Icons.check : Icons.add,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  onTap: () {
+                    showModalBottomSheet(
+                      context: context,
+                      isScrollControlled: true,
+                      backgroundColor: Colors.transparent,
+                      builder: (_) => const SelectPaymentTypeBottomSheet(),
+                    );
+                  },
+                );
+              },
+            ),
           ),
 
           SliverList.list(
@@ -157,29 +183,39 @@ class _CheckoutPageState extends State<CheckoutPage> {
         width: double.infinity,
         child: Consumer<CheckoutViewModel>(
           builder: (context, viewModel, _) {
+            final hasDeliveryDetails = viewModel.deliveryChoice == "pickup"
+                ? viewModel.selectedInpost != null
+                : viewModel.deliveryChoice == "home"
+                ? viewModel.hasShippingAddress &&
+                      viewModel.isShippingAddressConfirmed
+                : false;
 
-            final canPay =  viewModel.selectedPaymentType != null 
-              &&  viewModel.deliveryChoice != null 
-              &&  (viewModel.deliveryChoice != "pickup" || viewModel.selectedInpost != null)
-              &&  basket.total > 0 
-              && viewModel.createOrderStatus.type != StatusType.loading;
+            final canStartPayment =
+                viewModel.selectedPaymentType != null &&
+                hasDeliveryDetails &&
+                viewModel.total > 0 &&
+                !viewModel.isCheckoutProcessing &&
+                !viewModel.hasCompletedCheckout;
+
+            final canPay = viewModel.canRetryOrderCreation || canStartPayment;
 
             return FilledButton(
               onPressed: canPay
-              ? () async {
-                  final paid = await viewModel.payWithPaymentSheet(
-                    amount: basket.total,
-                  );
+                  ? () async {
+                      setState(() {
+                        _errorMessage = "";
+                      });
+                      if (viewModel.canRetryOrderCreation) {
+                        await viewModel.retryOrderCreation();
+                      } else {
+                        await viewModel.submitCheckout();
+                      }
+                    }
+                  : null,
 
-                  if (paid) {
-                    await viewModel.createOrder();
-                  }
-                }
-              : null, 
-
-              child: viewModel.createOrderStatus.type == StatusType.loading
-              ? const CircularProgressIndicator(color: Colors.white)
-              : Text(AppStrings.checkoutPay),
+              child: viewModel.isCheckoutProcessing
+                  ? const CircularProgressIndicator(color: Colors.white)
+                  : Text(viewModel.checkoutActionLabel),
             );
           },
         ),
@@ -194,8 +230,7 @@ class _CheckoutPageState extends State<CheckoutPage> {
 
   @override
   void dispose() {
-    vm.removeListener(_handleOrderStatus);
+    vm?.removeListener(_handleOrderStatus);
     super.dispose();
   }
-
 }

--- a/lib/features/checkout/checkout_repository.dart
+++ b/lib/features/checkout/checkout_repository.dart
@@ -131,14 +131,10 @@ final class CheckoutRepository implements ICheckoutRepository {
         data: order,
       );
       if (result.isSuccess && result.value != null) {
-        final data = result.value;
-
-        final jsonList = data['data'] ?? data;
-
-        return Result.success(jsonList);
+        return Result.success(result.value);
       } else {
         return Result.failure(
-          result.error ?? 'Error creating payment, please try again later',
+          result.error ?? 'Error creating order, please try again later',
         );
       }
     } catch (e) {

--- a/lib/features/checkout/checkout_view_model.dart
+++ b/lib/features/checkout/checkout_view_model.dart
@@ -10,10 +10,27 @@ import 'package:cherry_mvp/features/checkout/widgets/shipping_address_widget.dar
 import 'package:cherry_mvp/features/checkout/constants/address_constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_stripe/flutter_stripe.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:logging/logging.dart';
+
+enum CheckoutFlowState {
+  uninitialized,
+  paymentProcessing,
+  paymentCompleted,
+  orderCreationProcessing,
+  orderCreated,
+  shipmentCreated,
+  shipmentPending,
+  paymentFailure,
+  orderCreationFailure,
+  shipmentFailure,
+}
 
 /// ViewModel for managing checkout state including basket items, shipping address, and payment method
 class CheckoutViewModel extends ChangeNotifier {
+  static const int _mvpDefaultShippingWeightGrams = 500;
+  static const String _gbCountryCode = 'GB';
+
   final ICheckoutRepository checkoutRepository;
   final _log = Logger('CheckoutViewModel');
 
@@ -25,6 +42,33 @@ class CheckoutViewModel extends ChangeNotifier {
 
   Status _createOrderStatus = Status.uninitialized;
   Status get createOrderStatus => _createOrderStatus;
+
+  CheckoutFlowState _checkoutFlowState = CheckoutFlowState.uninitialized;
+  CheckoutFlowState get checkoutFlowState => _checkoutFlowState;
+
+  String? _lastPaymentIntentId;
+  String? get lastPaymentIntentId => _lastPaymentIntentId;
+
+  bool get isCheckoutProcessing =>
+      _checkoutFlowState == CheckoutFlowState.paymentProcessing ||
+      _checkoutFlowState == CheckoutFlowState.paymentCompleted ||
+      _checkoutFlowState == CheckoutFlowState.orderCreationProcessing;
+
+  bool get hasCompletedCheckout =>
+      _checkoutFlowState == CheckoutFlowState.shipmentCreated ||
+      _checkoutFlowState == CheckoutFlowState.shipmentPending;
+
+  bool get canRetryOrderCreation =>
+      _checkoutFlowState == CheckoutFlowState.orderCreationFailure &&
+      (_lastPaymentIntentId?.trim().isNotEmpty ?? false);
+
+  String get checkoutActionLabel {
+    if (canRetryOrderCreation) return AppStrings.checkoutRetryOrder;
+    if (_checkoutFlowState == CheckoutFlowState.shipmentPending) {
+      return AppStrings.checkoutDeliveryPending;
+    }
+    return AppStrings.checkoutPay;
+  }
 
   final List<Product> _basketItems = [];
 
@@ -210,6 +254,8 @@ class CheckoutViewModel extends ChangeNotifier {
     _basketItems.clear();
     deliveryChoice = null;
     _createOrderStatus = Status.uninitialized;
+    _checkoutFlowState = CheckoutFlowState.uninitialized;
+    _lastPaymentIntentId = null;
     notifyListeners();
   }
 
@@ -245,66 +291,14 @@ class CheckoutViewModel extends ChangeNotifier {
   /// Processes the checkout order
   /// Returns true if successful, false if validation fails or error occurs
   Future<bool> processCheckout() async {
-    if (!canCheckout) return false;
-    if (!validateShippingAddress()) return false;
+    if (selectedPaymentType == null) return false;
+    if (deliveryChoice != 'home' && deliveryChoice != 'pickup') return false;
+    if (deliveryChoice == 'home' && !validateShippingAddress()) return false;
+    if (deliveryChoice == 'pickup' && selectedInpost == null) return false;
 
-    try {
-      // Prepare order data for API call
-      final Map<String, dynamic> orderData = {
-        'items': basketItems
-            .map(
-              (item) => {
-                'id': item.id,
-                'name': item.name,
-                'price': item.price,
-                // Add other product fields as needed
-              },
-            )
-            .toList(),
-        'shipping_address': {
-          'formatted_address': formattedShippingAddress,
-          AddressConstants.streetKey:
-              shippingAddressComponents[AddressConstants.streetKey],
-          AddressConstants.cityKey:
-              shippingAddressComponents[AddressConstants.cityKey],
-          AddressConstants.stateKey:
-              shippingAddressComponents[AddressConstants.stateKey],
-          'postal_code':
-              shippingAddressComponents[AddressConstants.postalCodeKey],
-          AddressConstants.countryKey:
-              shippingAddressComponents[AddressConstants.countryKey],
-          'latitude': _shippingAddress?.latitude,
-          'longitude': _shippingAddress?.longitude,
-        },
-        'totals': {
-          'item_total': itemTotal,
-          'security_fee': securityFee,
-          'postage': postage,
-          'total': total,
-        },
-      };
-
-      // Validate order data structure
-      if (orderData['items'] == null || (orderData['items'] as List).isEmpty) {
-        return false;
-      }
-
-      // Call the repository to create the order via API
-      final result = await checkoutRepository.createOrder(orderData);
-
-      if (result.isSuccess) {
-        _log.info('Checkout processed successfully');
-        return true;
-      } else {
-        _log.warning('Checkout failed: ${result.error}');
-        return false;
-      }
-    } catch (e) {
-      // Log error for debugging purposes
-      _log.severe('Checkout error: $e');
-      debugPrint('${AddressConstants.checkoutError}: $e');
-      return false;
-    }
+    await submitCheckout();
+    return _checkoutFlowState == CheckoutFlowState.shipmentCreated ||
+        _checkoutFlowState == CheckoutFlowState.shipmentPending;
   }
 
   // fetch nearest inPost locker for pickup
@@ -429,15 +423,36 @@ class CheckoutViewModel extends ChangeNotifier {
     await checkoutRepository.storeOrderInFirestore(orderData);
   }
 
-  Future<bool> payWithPaymentSheet({required double amount}) async {
-    if (selectedPaymentType == null) {
-      _createOrderStatus = Status.failure(
-        AppStrings.checkoutPaymentMethodRequired,
+  Future<void> submitCheckout() async {
+    final paymentIntentId = await payWithPaymentSheet(amount: total);
+    if (paymentIntentId == null) return;
+
+    await createOrder(paymentIntentId: paymentIntentId);
+  }
+
+  Future<void> retryOrderCreation() async {
+    final paymentIntentId = _lastPaymentIntentId?.trim();
+    if (paymentIntentId == null || paymentIntentId.isEmpty) {
+      _setCheckoutFailure(
+        CheckoutFlowState.orderCreationFailure,
+        AppStrings.checkoutOrderCreationFailed,
       );
-      notifyListeners();
-      return false;
+      return;
     }
 
+    await createOrder(paymentIntentId: paymentIntentId);
+  }
+
+  Future<String?> payWithPaymentSheet({required double amount}) async {
+    if (selectedPaymentType == null) {
+      _setCheckoutFailure(
+        CheckoutFlowState.paymentFailure,
+        AppStrings.checkoutPaymentMethodRequired,
+      );
+      return null;
+    }
+
+    _checkoutFlowState = CheckoutFlowState.paymentProcessing;
     _createOrderStatus = Status.loading;
     notifyListeners();
 
@@ -447,6 +462,15 @@ class CheckoutViewModel extends ChangeNotifier {
 
       if (response.isSuccess && response.value != null) {
         final paymentResponse = response.value!;
+        final paymentIntentId = _resolvePaymentIntentId(paymentResponse);
+
+        if (paymentIntentId == null) {
+          _setCheckoutFailure(
+            CheckoutFlowState.paymentFailure,
+            AppStrings.checkoutPaymentDetailsUnavailable,
+          );
+          return null;
+        }
 
         Stripe.publishableKey = paymentResponse.publishableKey;
         await Stripe.instance.applySettings();
@@ -462,82 +486,337 @@ class CheckoutViewModel extends ChangeNotifier {
 
         // Present the native PaymentSheet (it will show ApplePay/GooglePay if available)
         await Stripe.instance.presentPaymentSheet();
-        return true;
-      } else {
-        _createOrderStatus = Status.failure(response.error.toString());
-        _log.severe('Create Payment intent Error :: ${response.error}');
+        _lastPaymentIntentId = paymentIntentId;
+        _checkoutFlowState = CheckoutFlowState.paymentCompleted;
+        _createOrderStatus = Status.loading;
         notifyListeners();
-        return false;
+        return paymentIntentId;
+      } else {
+        _setCheckoutFailure(
+          CheckoutFlowState.paymentFailure,
+          AppStrings.checkoutPaymentFailed,
+        );
+        _log.severe('Create Payment intent Error :: ${response.error}');
+        return null;
       }
     } on StripeException catch (e) {
-      _createOrderStatus = Status.failure(
-        e.error.localizedMessage ?? e.toString(),
-      );
-      _log.severe(
-        'Stripe Payment Error :: ${e.error.localizedMessage ?? e.toString()}',
-      );
+      final message = _isStripeCancellation(e)
+          ? AppStrings.checkoutPaymentCancelled
+          : AppStrings.checkoutPaymentFailed;
+      _checkoutFlowState = CheckoutFlowState.paymentFailure;
+      _createOrderStatus = Status(StatusType.canceled, message: message);
+      _log.severe('Stripe payment failed during PaymentSheet presentation');
       notifyListeners();
-      return false;
+      return null;
     } catch (e) {
-      _createOrderStatus = Status.failure(e.toString());
-      _log.severe('Error making payment::: $e');
-      notifyListeners();
-      return false;
+      _setCheckoutFailure(
+        CheckoutFlowState.paymentFailure,
+        AppStrings.checkoutPaymentFailed,
+      );
+      _log.severe('Unexpected payment failure');
+      return null;
     }
   }
 
-  Future<void> createOrder() async {
+  Future<void> createOrder({required String paymentIntentId}) async {
+    _checkoutFlowState = CheckoutFlowState.orderCreationProcessing;
     _createOrderStatus = Status.loading;
     notifyListeners();
 
-    if (basketItems.isEmpty) {
-      _createOrderStatus = Status.failure('Your basket is empty');
+    final validationMessage = _validateOrderCreatePayload(paymentIntentId);
+    if (validationMessage != null) {
+      _checkoutFlowState = CheckoutFlowState.orderCreationFailure;
+      _createOrderStatus = Status.failure(validationMessage);
       notifyListeners();
       return;
     }
 
-    final Map<String, dynamic> address = deliveryChoice == "pickup"
-        ? {
-            "line1": selectedInpost?.address ?? '',
-            "city": "London",
-            "state": "London",
-            "postal_code": selectedInpost?.postcode ?? '',
-            "country": AppStrings.unitedKingdomText,
-          }
-        : {
-            'line1': _shippingAddress?.line1 ?? '',
-            "city": shippingAddressComponents[AddressConstants.cityKey] ?? "",
-            "state": shippingAddressComponents[AddressConstants.stateKey] ?? "",
-            'postal_code':
-                shippingAddressComponents[AddressConstants.postalCodeKey] ?? "",
-            "country":
-                shippingAddressComponents[AddressConstants.countryKey] ??
-                AppStrings.unitedKingdomText,
-          };
-
-    final Map<String, dynamic> orderData = {
-      "amount": _toMinorUnits(total),
-      "productId": basketItems[0].id,
-      "productName": basketItems[0].name,
-      "shipping": {"address": address, "name": 'John Doe'},
-    };
+    final orderData = _buildOrderCreatePayload(paymentIntentId);
     try {
       final result = await checkoutRepository.createOrder(orderData);
       if (result.isSuccess) {
-        _createOrderStatus = Status.success;
+        _handleOrderCreateSuccess(result.value);
       } else {
-        _createOrderStatus = Status.failure(result.error ?? "");
+        _checkoutFlowState = CheckoutFlowState.orderCreationFailure;
+        _createOrderStatus = Status.failure(
+          result.error ?? AppStrings.checkoutOrderCreationFailed,
+        );
         _log.warning('Create order failed! ${result.error}');
+        notifyListeners();
       }
     } catch (e) {
-      _createOrderStatus = Status.failure(e.toString());
-      _log.severe('Create order failed! ${e.toString()}');
+      _checkoutFlowState = CheckoutFlowState.orderCreationFailure;
+      _createOrderStatus = Status.failure(
+        AppStrings.checkoutOrderCreationFailed,
+      );
+      _log.severe('Unexpected order creation failure');
+      notifyListeners();
     }
-    notifyListeners();
   }
 
   int _toMinorUnits(double amount) {
     return (amount * 100).round();
+  }
+
+  String? _validateOrderCreatePayload(String paymentIntentId) {
+    if (paymentIntentId.trim().isEmpty) {
+      return AppStrings.checkoutPaymentDetailsUnavailable;
+    }
+    if (basketItems.isEmpty) {
+      return 'Your basket is empty';
+    }
+    if (deliveryChoice == 'pickup' && selectedInpost == null) {
+      return AppStrings.checkoutPickupLockerRequired;
+    }
+    if (deliveryChoice == 'home' &&
+        (!hasShippingAddress ||
+            !isShippingAddressConfirmed ||
+            !validateShippingAddress())) {
+      return AppStrings.checkoutDeliveryAddressRequired;
+    }
+    if (deliveryChoice != 'pickup' && deliveryChoice != 'home') {
+      return AppStrings.checkoutDeliveryOptionRequired;
+    }
+    return null;
+  }
+
+  Map<String, dynamic> _buildOrderCreatePayload(String paymentIntentId) {
+    final product = basketItems.first;
+    final isPickup = deliveryChoice == 'pickup';
+    final deliveryType = isPickup ? 'pickup_point' : 'home';
+
+    // TODO: Replace these MVP fallback values with the selected Sendcloud
+    // shipping option once dynamic shipping options are wired into checkout.
+    final shippingOptionId = isPickup
+        ? 'mvp-pickup-point-delivery'
+        : 'mvp-home-delivery';
+    final shippingOptionName = isPickup
+        ? 'MVP pick-up point delivery'
+        : 'MVP home delivery';
+    final shippingCarrier = isPickup ? 'inpost' : 'evri';
+
+    final orderData = <String, dynamic>{
+      'amount': _toMinorUnits(total),
+      'paymentIntentId': paymentIntentId.trim(),
+      'deliveryType': deliveryType,
+      'shippingOptionId': shippingOptionId,
+      'shippingWeight': _mvpDefaultShippingWeightGrams,
+      'shipping': {
+        'address': isPickup
+            ? _buildPickupShippingAddress()
+            : _buildHomeShippingAddress(),
+        'name': _resolveShippingName(),
+      },
+      'productId': product.id,
+      'productName': product.name,
+      'shippingOptionName': shippingOptionName,
+      'shippingOptionPrice': isPickup ? 0 : _toMinorUnits(postage),
+      'shippingCarrier': shippingCarrier,
+    };
+
+    if (isPickup) {
+      orderData['pickupPoint'] = _buildPickupPoint(shippingCarrier);
+    }
+
+    return orderData;
+  }
+
+  Map<String, dynamic> _buildHomeShippingAddress() {
+    final address = <String, dynamic>{
+      'line1':
+          (shippingAddressComponents[AddressConstants.streetKey] ??
+                  _shippingAddress?.line1 ??
+                  '')
+              .trim(),
+      'city': (shippingAddressComponents[AddressConstants.cityKey] ?? '')
+          .trim(),
+      'postal_code':
+          (shippingAddressComponents[AddressConstants.postalCodeKey] ?? '')
+              .trim(),
+      'country': _gbCountryCode,
+    };
+
+    final state = (shippingAddressComponents[AddressConstants.stateKey] ?? '')
+        .trim();
+    if (state.isNotEmpty) {
+      address['state'] = state;
+    }
+
+    return address;
+  }
+
+  Map<String, dynamic> _buildPickupShippingAddress() {
+    final pickupPoint = selectedInpost!;
+    final city = _pickupPointCity(pickupPoint);
+    final addressLine1 = _pickupPointAddressLine1(pickupPoint);
+
+    return {
+      'line1': addressLine1,
+      'city': city,
+      'postal_code': pickupPoint.postcode.trim(),
+      'country': _gbCountryCode,
+    };
+  }
+
+  Map<String, dynamic> _buildPickupPoint(String carrier) {
+    final pickupPoint = selectedInpost!;
+    return {
+      'id': pickupPoint.id,
+      'name': pickupPoint.name,
+      'addressLine1': _pickupPointAddressLine1(pickupPoint),
+      'city': _pickupPointCity(pickupPoint),
+      'postalCode': pickupPoint.postcode.trim(),
+      'country': _gbCountryCode,
+      'carrier': carrier,
+    };
+  }
+
+  String _pickupPointAddressLine1(InpostModel pickupPoint) {
+    final parts = pickupPoint.address
+        .split(',')
+        .map((part) => part.trim())
+        .where((part) => part.isNotEmpty)
+        .toList();
+    return parts.isNotEmpty ? parts.first : pickupPoint.address.trim();
+  }
+
+  String _pickupPointCity(InpostModel pickupPoint) {
+    final parts = pickupPoint.address
+        .split(',')
+        .map((part) => part.trim())
+        .where((part) => part.isNotEmpty)
+        .toList();
+    if (parts.length > 1) return parts.last;
+
+    final nameParts = pickupPoint.name
+        .split('-')
+        .map((part) => part.trim())
+        .where((part) => part.isNotEmpty)
+        .toList();
+    if (nameParts.length > 1) return nameParts.last;
+
+    // TODO: Replace this fallback when pickup point data includes a city field.
+    return 'London';
+  }
+
+  String _resolveShippingName() {
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      final displayName = user?.displayName?.trim();
+      if (displayName != null && displayName.isNotEmpty) {
+        return displayName;
+      }
+
+      final email = user?.email?.trim();
+      if (email != null && email.isNotEmpty) {
+        final emailPrefix = email.split('@').first.trim();
+        if (emailPrefix.isNotEmpty) return emailPrefix;
+      }
+    } catch (_) {
+      // Firebase may be unavailable in tests. The fallback remains safe.
+    }
+
+    return 'cherry customer';
+  }
+
+  void _handleOrderCreateSuccess(dynamic payload) {
+    _checkoutFlowState = CheckoutFlowState.orderCreated;
+
+    final shipmentStatus = _readShipmentStatus(payload).toLowerCase();
+    if (shipmentStatus == 'pending') {
+      _checkoutFlowState = CheckoutFlowState.shipmentPending;
+      _createOrderStatus = Status(
+        StatusType.success,
+        message: AppStrings.checkoutShipmentPending,
+      );
+      notifyListeners();
+      return;
+    }
+
+    if (shipmentStatus == 'failed' ||
+        shipmentStatus == 'failure' ||
+        shipmentStatus == 'error') {
+      _checkoutFlowState = CheckoutFlowState.shipmentFailure;
+      _createOrderStatus = Status.failure(AppStrings.checkoutShipmentFailed);
+      notifyListeners();
+      return;
+    }
+
+    _checkoutFlowState = CheckoutFlowState.shipmentCreated;
+    _createOrderStatus = Status.success;
+    notifyListeners();
+  }
+
+  String _readShipmentStatus(dynamic payload) {
+    final map = _toStringMap(payload);
+    if (map == null) return '';
+
+    final explicitStatus = _firstTextValue([
+      map['shipmentStatus'],
+      map['shipment_status'],
+    ]);
+    if (explicitStatus.isNotEmpty) return explicitStatus;
+
+    final shipment = _toStringMap(map['shipment']);
+    if (shipment != null) {
+      final shipmentStatus = _firstTextValue([
+        shipment['shipmentStatus'],
+        shipment['shipment_status'],
+        shipment['status'],
+      ]);
+      if (shipmentStatus.isNotEmpty) return shipmentStatus;
+    }
+
+    final dataStatus = _readShipmentStatus(map['data']);
+    if (dataStatus.isNotEmpty) return dataStatus;
+
+    return _firstTextValue([map['status']]);
+  }
+
+  String _firstTextValue(List<dynamic> candidates) {
+    for (final candidate in candidates) {
+      final value = candidate?.toString().trim();
+      if (value != null && value.isNotEmpty) return value;
+    }
+    return '';
+  }
+
+  Map<String, dynamic>? _toStringMap(dynamic value) {
+    if (value is Map<String, dynamic>) return value;
+    if (value is Map) return Map<String, dynamic>.from(value);
+    return null;
+  }
+
+  void _setCheckoutFailure(CheckoutFlowState state, String message) {
+    _checkoutFlowState = state;
+    _createOrderStatus = Status.failure(message);
+    notifyListeners();
+  }
+
+  bool _isStripeCancellation(StripeException error) {
+    final message = error.error.localizedMessage?.toLowerCase() ?? '';
+    final code = error.error.code.name.toLowerCase();
+    return message.contains('cancel') || code.contains('cancel');
+  }
+
+  String? _resolvePaymentIntentId(PaymentIntentResponse paymentResponse) {
+    final explicitPaymentIntentId = paymentResponse.paymentIntentId?.trim();
+    if (explicitPaymentIntentId != null && explicitPaymentIntentId.isNotEmpty) {
+      return explicitPaymentIntentId;
+    }
+
+    return _paymentIntentIdFromClientSecret(paymentResponse.paymentIntent);
+  }
+
+  String? _paymentIntentIdFromClientSecret(String clientSecret) {
+    final trimmed = clientSecret.trim();
+    const secretDelimiter = '_secret_';
+    final secretIndex = trimmed.indexOf(secretDelimiter);
+    if (secretIndex <= 0) return null;
+
+    // TODO: Ask the backend to return paymentIntentId explicitly so the
+    // frontend does not need to derive it from the Stripe client secret.
+    return trimmed.substring(0, secretIndex);
   }
 
   SetupPaymentSheetParameters _buildPaymentSheetParameters(

--- a/lib/features/checkout/models/payment_intent.dart
+++ b/lib/features/checkout/models/payment_intent.dart
@@ -20,6 +20,7 @@ class PaymentIntentResponse {
   Map<String, dynamic> toJson() => _$PaymentIntentResponseToJson(this);
 
   String get paymentIntent => data.paymentIntent;
+  String? get paymentIntentId => data.paymentIntentId;
   String get ephemeralKey => data.ephemeralKey;
   String get customer => data.customer;
   String get publishableKey => data.publishableKey;
@@ -28,12 +29,14 @@ class PaymentIntentResponse {
 @JsonSerializable()
 class PaymentIntentData {
   final String paymentIntent;
+  final String? paymentIntentId;
   final String ephemeralKey;
   final String customer;
   final String publishableKey;
 
   PaymentIntentData({
     required this.paymentIntent,
+    this.paymentIntentId,
     required this.ephemeralKey,
     required this.customer,
     required this.publishableKey,

--- a/lib/features/checkout/models/payment_intent.g.dart
+++ b/lib/features/checkout/models/payment_intent.g.dart
@@ -25,6 +25,7 @@ Map<String, dynamic> _$PaymentIntentResponseToJson(
 PaymentIntentData _$PaymentIntentDataFromJson(Map<String, dynamic> json) =>
     PaymentIntentData(
       paymentIntent: json['paymentIntent'] as String,
+      paymentIntentId: json['paymentIntentId'] as String?,
       ephemeralKey: json['ephemeralKey'] as String,
       customer: json['customer'] as String,
       publishableKey: json['publishableKey'] as String,
@@ -33,6 +34,7 @@ PaymentIntentData _$PaymentIntentDataFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$PaymentIntentDataToJson(PaymentIntentData instance) =>
     <String, dynamic>{
       'paymentIntent': instance.paymentIntent,
+      'paymentIntentId': instance.paymentIntentId,
       'ephemeralKey': instance.ephemeralKey,
       'customer': instance.customer,
       'publishableKey': instance.publishableKey,

--- a/lib/features/checkout/widgets/delivery_options.dart
+++ b/lib/features/checkout/widgets/delivery_options.dart
@@ -3,12 +3,14 @@
 import 'package:cherry_mvp/core/config/config.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
 import 'package:cherry_mvp/features/checkout/checkout_view_model.dart';
+import 'package:cherry_mvp/features/checkout/payment_type.dart';
 import 'package:cherry_mvp/features/checkout/widgets/outlined.dart';
 import 'package:cherry_mvp/features/checkout/purchase_security.dart';
 import 'package:cherry_mvp/features/checkout/widgets/pickup_points_empty_widget.dart';
 import 'package:cherry_mvp/features/checkout/widgets/pickup_points_error_widget.dart';
 import 'package:cherry_mvp/features/checkout/widgets/pickup_points_loading_widget.dart';
 import 'package:cherry_mvp/features/checkout/widgets/price_list_item.dart';
+import 'package:cherry_mvp/features/checkout/widgets/select_payment_type_bottom_sheet.dart';
 import 'package:cherry_mvp/features/checkout/widgets/share_location_dialog.dart';
 import 'package:cherry_mvp/features/checkout/widgets/shipping_address_widget.dart';
 import 'package:cherry_mvp/features/checkout/widgets/shipping_list_item.dart';
@@ -39,7 +41,7 @@ class _DeliveryOptionsState extends State<DeliveryOptions> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final vm = context.read<CheckoutViewModel>();
 
-      if (vm.deliveryChoice!.isNotEmpty) {
+      if ((vm.deliveryChoice ?? '').isNotEmpty) {
         setState(() {
           _delivery = vm.deliveryChoice;
           _deliverExpanded = _delivery == 'pickup' && vm.selectedInpost != null;
@@ -48,6 +50,16 @@ class _DeliveryOptionsState extends State<DeliveryOptions> {
     });
   }
 
+  String _paymentTypeLabel(PaymentType type) {
+    switch (type) {
+      case PaymentType.card:
+        return AppStrings.paymentMethodsCard;
+      case PaymentType.google:
+        return AppStrings.paymentMethodsGooglePay;
+      case PaymentType.apple:
+        return AppStrings.paymentMethodsApplePay;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -419,6 +431,45 @@ class _DeliveryOptionsState extends State<DeliveryOptions> {
               },
             ),
           ],
+          const SizedBox(height: 16),
+          Text(
+            AppStrings.checkoutPayment,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Consumer<CheckoutViewModel>(
+            builder: (context, model, _) {
+              final selectedType = model.selectedPaymentType;
+              return Outlined(
+                child: ListTile(
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                  leading: const Icon(Icons.credit_card),
+                  title: Text(
+                    selectedType == null
+                        ? AppStrings.checkoutChoosePayment
+                        : _paymentTypeLabel(selectedType),
+                  ),
+                  subtitle: selectedType == null
+                      ? Text(
+                          AppStrings.paymentMethodsChoose,
+                          style: Theme.of(context).textTheme.labelSmall,
+                        )
+                      : null,
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () async {
+                    await showModalBottomSheet<PaymentType>(
+                      context: context,
+                      isScrollControlled: true,
+                      builder: (context) =>
+                          const SelectPaymentTypeBottomSheet(),
+                    );
+                  },
+                ),
+              );
+            },
+          ),
           const Divider(height: 16),
         ],
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:cherry_mvp/core/config/app_theme.dart';
 import 'package:cherry_mvp/features/welcome/widgets/auth_gate.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'core/utils/utils.dart';
 import 'package:flutter/material.dart';
@@ -14,7 +17,21 @@ void main() async {
 
   /// Load environment variables
   await dotenv.load();
+
   await Firebase.initializeApp();
+
+  // Connect to local emulators in debug mode
+  if (kDebugMode) {
+    try {
+      const host = 'localhost';
+      await FirebaseAuth.instance.useAuthEmulator(host, 9099);
+      FirebaseFirestore.instance.useFirestoreEmulator(host, 8080);
+      print('Connected to Firebase Emulators');
+    } catch (e) {
+      print('Failed to connect to Firebase Emulators: $e');
+    }
+  }
+
   SharedPreferences prefs = await SharedPreferences.getInstance();
 
   runApp(MultiProvider(providers: [...buildProviders(prefs)], child: MyApp()));

--- a/test/checkout_view_model_test.dart
+++ b/test/checkout_view_model_test.dart
@@ -1,23 +1,54 @@
+import 'package:cherry_mvp/core/models/inpost_model.dart';
+import 'package:cherry_mvp/core/models/product.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/core/utils/status.dart';
 import 'package:cherry_mvp/features/checkout/checkout_repository.dart';
 import 'package:cherry_mvp/features/checkout/checkout_view_model.dart';
 import 'package:cherry_mvp/features/checkout/widgets/shipping_address_widget.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class FakeCheckoutRepository implements ICheckoutRepository {
+  Map<String, dynamic>? createdOrder;
+  Result<dynamic> createOrderResult = Result.success({
+    'shipment': {'id': 'shipment_123'},
+  });
+
   @override
   Future<void> storeOrderInFirestore(Map<String, dynamic> orderData) async {}
+
+  @override
+  Future<Result> createOrder(Map<String, dynamic> order) async {
+    createdOrder = order;
+    return createOrderResult;
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+Product _testProduct({double price = 10}) {
+  return Product(
+    id: 'product_1',
+    name: 'Blue jacket',
+    description: 'Warm jacket',
+    quality: 'Good',
+    productImages: const [],
+    donation: price,
+    price: price,
+    likes: 0,
+    number: 1,
+    size: 'M',
+  );
+}
+
 void main() {
   group('CheckoutViewModel', () {
     late CheckoutViewModel viewModel;
+    late FakeCheckoutRepository repository;
 
     setUp(() {
-      viewModel =
-          CheckoutViewModel(checkoutRepository: FakeCheckoutRepository());
+      repository = FakeCheckoutRepository();
+      viewModel = CheckoutViewModel(checkoutRepository: repository);
     });
 
     test('should initialize with empty state', () {
@@ -51,8 +82,8 @@ void main() {
             types: ['administrative_area_level_1'],
           ),
           AddressComponent(
-            longName: '12345',
-            shortName: '12345',
+            longName: 'BS1 6PL',
+            shortName: 'BS1 6PL',
             types: ['postal_code'],
           ),
           AddressComponent(
@@ -64,7 +95,7 @@ void main() {
       );
 
       viewModel.setShippingAddress(testAddress);
-      
+
       expect(viewModel.hasShippingAddress, true);
       expect(viewModel.shippingAddress, testAddress);
       expect(viewModel.formattedShippingAddress, 'Test Address');
@@ -94,8 +125,8 @@ void main() {
             types: ['locality'],
           ),
           AddressComponent(
-            longName: '12345',
-            shortName: '12345',
+            longName: 'BS1 6PL',
+            shortName: 'BS1 6PL',
             types: ['postal_code'],
           ),
         ],
@@ -107,10 +138,10 @@ void main() {
 
     test('should handle payment method correctly', () {
       expect(viewModel.hasPaymentMethod, false);
-      
+
       viewModel.setPaymentMethod(true);
       expect(viewModel.hasPaymentMethod, true);
-      
+
       viewModel.setPaymentMethod(false);
       expect(viewModel.hasPaymentMethod, false);
     });
@@ -141,15 +172,15 @@ void main() {
         formattedAddress: 'Test Address',
         addressComponents: [],
       );
-      
+
       viewModel.setShippingAddress(testAddress);
       viewModel.setPaymentMethod(true);
-      
+
       expect(viewModel.hasShippingAddress, true);
       expect(viewModel.hasPaymentMethod, true);
-      
+
       viewModel.resetCheckout();
-      
+
       expect(viewModel.hasShippingAddress, false);
       expect(viewModel.hasPaymentMethod, false);
       expect(viewModel.canCheckout, false);
@@ -188,12 +219,115 @@ void main() {
       );
 
       viewModel.setShippingAddress(testAddress);
-      
+
       final components = viewModel.shippingAddressComponents;
       expect(components['street'], '123 Main St');
       expect(components['city'], 'Anytown');
       expect(components['state'], 'NY');
       expect(components['postalCode'], '12345');
     });
+
+    test('createOrder sends backend payload for home delivery', () async {
+      viewModel.addItem(_testProduct());
+      viewModel.setDeliveryChoice('home');
+      viewModel.setShippingAddress(
+        PlaceDetails.fromManualEntry(
+          addressLine1: '12 Cherry Lane',
+          addressLine2: 'Flat 2',
+          city: 'Bristol',
+          postcode: 'BS1 6PL',
+          country: 'United Kingdom',
+        ),
+      );
+      viewModel.setAddressConfirmed(true);
+
+      await viewModel.createOrder(paymentIntentId: 'pi_123');
+
+      final payload = repository.createdOrder!;
+      expect(payload['amount'], 1399);
+      expect(payload['paymentIntentId'], 'pi_123');
+      expect(payload['deliveryType'], 'home');
+      expect(payload['shippingOptionId'], isNotEmpty);
+      expect(payload['shippingWeight'], 500);
+      expect(payload['productId'], 'product_1');
+      expect(payload['productName'], 'Blue jacket');
+      expect(payload['shippingOptionPrice'], 299);
+      expect(payload['shippingCarrier'], isNotEmpty);
+
+      final shipping = payload['shipping'] as Map<String, dynamic>;
+      expect(shipping['name'], isNot('John Doe'));
+
+      final address = shipping['address'] as Map<String, dynamic>;
+      expect(address['line1'], '12 Cherry Lane');
+      expect(address['city'], 'Bristol');
+      expect(address['postal_code'], 'BS1 6PL');
+      expect(address['country'], 'GB');
+      expect(viewModel.checkoutFlowState, CheckoutFlowState.shipmentCreated);
+    });
+
+    test('createOrder sends backend payload for pickup delivery', () async {
+      viewModel.addItem(_testProduct());
+      viewModel.setDeliveryChoice('pickup');
+      viewModel.setSelectedInpost(
+        const InpostModel(
+          id: 'locker_1',
+          name: 'Aldi Locker - Temple Gate',
+          address: 'Temple Gate, Bristol',
+          postcode: 'BS1 6PL',
+          lat: '51.4490',
+          long: '-2.5830',
+        ),
+      );
+
+      await viewModel.createOrder(paymentIntentId: 'pi_456');
+
+      final payload = repository.createdOrder!;
+      expect(payload['paymentIntentId'], 'pi_456');
+      expect(payload['deliveryType'], 'pickup_point');
+      expect(payload['shippingOptionId'], isNotEmpty);
+      expect(payload['shippingWeight'], 500);
+
+      final shipping = payload['shipping'] as Map<String, dynamic>;
+      final address = shipping['address'] as Map<String, dynamic>;
+      expect(address['line1'], 'Temple Gate');
+      expect(address['city'], 'Bristol');
+      expect(address['postal_code'], 'BS1 6PL');
+      expect(address['country'], 'GB');
+
+      final pickupPoint = payload['pickupPoint'] as Map<String, dynamic>;
+      expect(pickupPoint['id'], 'locker_1');
+      expect(pickupPoint['name'], 'Aldi Locker - Temple Gate');
+      expect(pickupPoint['addressLine1'], 'Temple Gate');
+      expect(pickupPoint['city'], 'Bristol');
+      expect(pickupPoint['postalCode'], 'BS1 6PL');
+      expect(pickupPoint['country'], 'GB');
+      expect(pickupPoint['carrier'], isNotEmpty);
+    });
+
+    test(
+      'createOrder treats shipmentStatus pending as partial success',
+      () async {
+        repository.createOrderResult = Result.success({
+          'shipmentStatus': 'pending',
+        });
+        viewModel.addItem(_testProduct());
+        viewModel.setDeliveryChoice('pickup');
+        viewModel.setSelectedInpost(
+          const InpostModel(
+            id: 'locker_1',
+            name: 'Aldi Locker - Temple Gate',
+            address: 'Temple Gate, Bristol',
+            postcode: 'BS1 6PL',
+            lat: '51.4490',
+            long: '-2.5830',
+          ),
+        );
+
+        await viewModel.createOrder(paymentIntentId: 'pi_789');
+
+        expect(viewModel.checkoutFlowState, CheckoutFlowState.shipmentPending);
+        expect(viewModel.createOrderStatus.type, StatusType.success);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

For https://github.com/Cherry-CIC/MVP/issues/397

- Refactors the checkout flow to wait for Stripe PaymentSheet success before creating an order through `POST /api/order/create`.
- Reworks checkout state in `CheckoutViewModel` and `CheckoutPage` so payment, order creation, and shipment outcomes are handled separately.
- Builds the backend order payload from existing checkout state, including `paymentIntentId`, delivery type, shipping details, and fallback shipping option values for the current MVP.
- Removes the dummy Firestore order write from the main submit path and keeps the existing repository/API pattern intact.
- Tightens API logging so Stripe client secrets and bearer tokens are not logged via Dio in normal use.
- Adds focused ViewModel tests for home delivery, pick-up delivery, and pending shipment responses.

## Testing
- Added unit coverage for backend payload construction and shipment-pending handling.
- Ran formatting on touched Dart files.
- `flutter analyze` and `flutter test` were attempted, but this repo hit the known Flutter tool hang during analysis and test loading, so full automated verification did not complete in this environment.