### PR TITLE
Fix Android NDK version configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 android {
     namespace = "uk.org.cherry.app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = localProperties.getProperty("flutter.ndkVersion")
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
## Summary
Fixes the Android build configuration by using Flutter’s provided NDK version directly.

## Reason
`flutter.ndkVersion` is not generated in `android/local.properties`, so reading it from `local.properties` can return null and cause the Android build to fail.

## Change
Changed:

`ndkVersion = localProperties.getProperty("flutter.ndkVersion")`

to:

`ndkVersion = flutter.ndkVersion`

## Testing
Tested locally with:

`flutter clean`
`flutter pub get`
`flutter run -d V2027`

Result: the app builds and opens successfully on a real Android device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to use a more consistent NDK version source, helping improve build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->