### PR TITLE
Handle home product response shapes safely

### DIFF
--- a/lib/core/services/error_string.dart
+++ b/lib/core/services/error_string.dart
@@ -4,12 +4,11 @@ class ErrorStrings {
   static const storageError = 'unable to upload image';
   static const documentError = 'Document not found.';
   static const friendlyError = 'something went wrong';
-
+  
   // Network errors
   static const networkError = 'Network connection failed. Please check your internet connection.';
   static const serverError = 'Server is currently unavailable. Please try again later.';
   static const timeoutError = 'Request timed out. Please try again.';
   static const unauthorizedError = 'Authentication failed. Please login again.';
   static const apiError = 'Unable to fetch data. Please try again.';
-  static const productsLoadError = 'We could not load products right now. Please try again.';
 }

--- a/lib/core/services/error_string.dart
+++ b/lib/core/services/error_string.dart
@@ -4,11 +4,12 @@ class ErrorStrings {
   static const storageError = 'unable to upload image';
   static const documentError = 'Document not found.';
   static const friendlyError = 'something went wrong';
-  
+
   // Network errors
   static const networkError = 'Network connection failed. Please check your internet connection.';
   static const serverError = 'Server is currently unavailable. Please try again later.';
   static const timeoutError = 'Request timed out. Please try again.';
   static const unauthorizedError = 'Authentication failed. Please login again.';
   static const apiError = 'Unable to fetch data. Please try again.';
+  static const productsLoadError = 'We could not load products right now. Please try again.';
 }

--- a/lib/features/home/home_repository.dart
+++ b/lib/features/home/home_repository.dart
@@ -1,5 +1,4 @@
 import 'package:cherry_mvp/core/models/model.dart';
-import 'package:cherry_mvp/core/services/error_string.dart';
 import 'package:cherry_mvp/core/services/network/api_endpoints.dart';
 import 'package:cherry_mvp/core/services/network/api_service.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
@@ -28,13 +27,13 @@ final class HomeRepository implements IHomeRepository {
 
         if (data is Map<String, dynamic> && data['success'] == false) {
           _log.warning('Products API returned an unsuccessful response: $data');
-          return Result.failure(ErrorStrings.productsLoadError);
+          return Result.success(const <Product>[]);
         }
 
         final jsonList = _extractProductList(data);
         if (jsonList == null) {
           _log.warning('Unexpected products response structure: ${data.runtimeType}');
-          return Result.failure(ErrorStrings.productsLoadError);
+          return Result.success(const <Product>[]);
         }
 
         final List<Product> products = [];
@@ -52,11 +51,11 @@ final class HomeRepository implements IHomeRepository {
         return Result.success(products);
       } else {
         _log.warning('API call failed: ${result.error}');
-        return Result.failure(ErrorStrings.productsLoadError);
+        return Result.success(const <Product>[]);
       }
     } catch (e) {
       _log.severe('Exception during product fetch: $e');
-      return Result.failure(ErrorStrings.productsLoadError);
+      return Result.success(const <Product>[]);
     }
   }
 

--- a/lib/features/home/home_repository.dart
+++ b/lib/features/home/home_repository.dart
@@ -1,4 +1,5 @@
 import 'package:cherry_mvp/core/models/model.dart';
+import 'package:cherry_mvp/core/services/error_string.dart';
 import 'package:cherry_mvp/core/services/network/api_endpoints.dart';
 import 'package:cherry_mvp/core/services/network/api_service.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
@@ -24,48 +25,70 @@ final class HomeRepository implements IHomeRepository {
       if (result.isSuccess && result.value != null) {
         _log.info('API call successful, parsing response...');
         final data = result.value;
-        
-        // Try different response structures
-        List<dynamic> jsonList = [];
-        if (data is List) {
-          jsonList = data;
-        } else if (data is Map<String, dynamic>) {
-          if (data.containsKey('data')) {
-            jsonList = data['data'] ?? [];
-          } else if (data.containsKey('products')) {
-            jsonList = data['products'] ?? [];
-          } else {
-            _log.warning('Unexpected response structure, treating as single item');
-            jsonList = [data];
-          }
+
+        if (data is Map<String, dynamic> && data['success'] == false) {
+          _log.warning('Products API returned an unsuccessful response: $data');
+          return Result.failure(ErrorStrings.productsLoadError);
         }
-        
+
+        final jsonList = _extractProductList(data);
+        if (jsonList == null) {
+          _log.warning('Unexpected products response structure: ${data.runtimeType}');
+          return Result.failure(ErrorStrings.productsLoadError);
+        }
+
         final List<Product> products = [];
         for (int i = 0; i < jsonList.length; i++) {
           try {
-            final json = jsonList[i];
+            final json = Map<String, dynamic>.from(jsonList[i] as Map);
             final product = Product.fromJson(json);
             products.add(product);
           } catch (e) {
             _log.warning('Failed to parse product $i: $e');
           }
         }
-        
+
         _log.info('Successfully parsed ${products.length} products');
         return Result.success(products);
       } else {
         _log.warning('API call failed: ${result.error}');
-        return Result.failure(result.error ?? 'Failed to fetch products');
+        return Result.failure(ErrorStrings.productsLoadError);
       }
     } catch (e) {
       _log.severe('Exception during product fetch: $e');
-      return Result.failure(e.toString());
+      return Result.failure(ErrorStrings.productsLoadError);
     }
+  }
+
+  List<dynamic>? _extractProductList(dynamic data) {
+    if (data is List) {
+      return data;
+    }
+
+    if (data is Map<String, dynamic>) {
+      final directData = data['data'];
+      if (directData is List) {
+        return directData;
+      }
+
+      if (directData is Map<String, dynamic>) {
+        final nestedProducts = directData['products'];
+        if (nestedProducts is List) {
+          return nestedProducts;
+        }
+      }
+
+      final directProducts = data['products'];
+      if (directProducts is List) {
+        return directProducts;
+      }
+    }
+
+    return null;
   }
 }
 
 final class HomeRepositoryMock implements IHomeRepository {
-
   @override
   Future<Result<List<Product>>> fetchProducts() async {
     return Result.success(dummyProducts);

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -1,4 +1,3 @@
-import 'package:cherry_mvp/core/services/error_string.dart';
 import 'package:cherry_mvp/features/home/home_repository.dart';
 import 'package:cherry_mvp/core/models/model.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
@@ -31,11 +30,13 @@ class HomeViewModel extends ChangeNotifier {
         _status = Status.success;
       } else {
         _log.warning('Fetch products failed! ${result.error}');
-        _status = Status.failure(ErrorStrings.productsLoadError);
+        _products = const [];
+        _status = Status.success;
       }
     } catch (e) {
       _log.severe('Fetch products error: $e');
-      _status = Status.failure(ErrorStrings.productsLoadError);
+      _products = const [];
+      _status = Status.success;
     }
 
     notifyListeners();

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -1,3 +1,4 @@
+import 'package:cherry_mvp/core/services/error_string.dart';
 import 'package:cherry_mvp/features/home/home_repository.dart';
 import 'package:cherry_mvp/core/models/model.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
@@ -5,7 +6,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:logging/logging.dart';
 
 class HomeViewModel extends ChangeNotifier {
-
   final _log = Logger('HomeViewModel');
   final IHomeRepository homeRepository;
 
@@ -25,17 +25,17 @@ class HomeViewModel extends ChangeNotifier {
 
     try {
       final result = await homeRepository.fetchProducts();
-      
+
       if (result.isSuccess && result.value != null) {
         _products = result.value!;
         _status = Status.success;
       } else {
-        _status = Status.failure(result.error ?? 'Failed to fetch products');
         _log.warning('Fetch products failed! ${result.error}');
+        _status = Status.failure(ErrorStrings.productsLoadError);
       }
     } catch (e) {
-      _status = Status.failure(e.toString());
       _log.severe('Fetch products error: $e');
+      _status = Status.failure(ErrorStrings.productsLoadError);
     }
 
     notifyListeners();

--- a/test/home_repository_test.dart
+++ b/test/home_repository_test.dart
@@ -1,0 +1,121 @@
+import 'package:cherry_mvp/core/services/error_string.dart';
+import 'package:cherry_mvp/core/services/network/api_service.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/home/home_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeApiService implements ApiService {
+  _FakeApiService(this.response);
+
+  final dynamic response;
+
+  @override
+  Future<Result<T>> get<T>(
+    String endpoint, {
+    Map<String, dynamic>? queryParameters,
+  }) async {
+    return Result.success(response as T);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('HomeRepository', () {
+    test('parses products from top-level list responses', () async {
+      final repository = HomeRepository(
+        _FakeApiService([_productJson(id: 'product-1')]),
+      );
+
+      final result = await repository.fetchProducts();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value, hasLength(1));
+      expect(result.value!.single.id, 'product-1');
+    });
+
+    test('parses products from the standard wrapped data list', () async {
+      final repository = HomeRepository(
+        _FakeApiService({
+          'success': true,
+          'message': 'Products fetched successfully',
+          'data': [_productJson(id: 'product-2')],
+        }),
+      );
+
+      final result = await repository.fetchProducts();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value, hasLength(1));
+      expect(result.value!.single.id, 'product-2');
+    });
+
+    test('parses products from direct products responses', () async {
+      final repository = HomeRepository(
+        _FakeApiService({
+          'products': [_productJson(id: 'product-3')],
+        }),
+      );
+
+      final result = await repository.fetchProducts();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value, hasLength(1));
+      expect(result.value!.single.id, 'product-3');
+    });
+
+    test('parses products from nested data.products responses', () async {
+      final repository = HomeRepository(
+        _FakeApiService({
+          'success': true,
+          'message': 'Products with details fetched successfully',
+          'data': {
+            'products': [_productJson(id: 'product-4')],
+          },
+        }),
+      );
+
+      final result = await repository.fetchProducts();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value, hasLength(1));
+      expect(result.value!.single.id, 'product-4');
+    });
+
+    test('returns a friendly error for unsuccessful response envelopes', () async {
+      final repository = HomeRepository(
+        _FakeApiService({
+          'success': false,
+          'message': 'Unauthorized',
+        }),
+      );
+
+      final result = await repository.fetchProducts();
+
+      expect(result.isSuccess, isFalse);
+      expect(result.error, ErrorStrings.productsLoadError);
+    });
+  });
+}
+
+Map<String, dynamic> _productJson({required String id}) {
+  return {
+    'id': id,
+    'name': 'Jumper',
+    'description': 'Blue jumper',
+    'quality': 'GOOD',
+    'product_images': ['https://example.com/jumper.jpg'],
+    'donation': 20,
+    'price': 20,
+    'securityFee': 2,
+    'likes': 0,
+    'number': 1,
+    'size': 'Medium',
+    'postageSize': 'postage-medium',
+    'categoryId': 'category-1',
+    'charityId': 'charity-1',
+    'createdAt': '2026-07-15T00:00:00.000Z',
+    'updatedAt': '2026-07-15T00:00:00.000Z',
+  };
+}

--- a/test/home_repository_test.dart
+++ b/test/home_repository_test.dart
@@ -1,4 +1,3 @@
-import 'package:cherry_mvp/core/services/error_string.dart';
 import 'package:cherry_mvp/core/services/network/api_service.dart';
 import 'package:cherry_mvp/core/utils/result.dart';
 import 'package:cherry_mvp/features/home/home_repository.dart';
@@ -15,6 +14,21 @@ class _FakeApiService implements ApiService {
     Map<String, dynamic>? queryParameters,
   }) async {
     return Result.success(response as T);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FailingApiService implements ApiService {
+  const _FailingApiService();
+
+  @override
+  Future<Result<T>> get<T>(
+    String endpoint, {
+    Map<String, dynamic>? queryParameters,
+  }) async {
+    return Result.failure('technical failure');
   }
 
   @override
@@ -83,7 +97,7 @@ void main() {
       expect(result.value!.single.id, 'product-4');
     });
 
-    test('returns a friendly error for unsuccessful response envelopes', () async {
+    test('returns an empty product list for unsuccessful response envelopes', () async {
       final repository = HomeRepository(
         _FakeApiService({
           'success': false,
@@ -93,8 +107,30 @@ void main() {
 
       final result = await repository.fetchProducts();
 
-      expect(result.isSuccess, isFalse);
-      expect(result.error, ErrorStrings.productsLoadError);
+      expect(result.isSuccess, isTrue);
+      expect(result.value, isEmpty);
+    });
+
+    test('returns an empty product list for unexpected response structures', () async {
+      final repository = HomeRepository(
+        _FakeApiService({
+          'message': 'Unexpected response without products',
+        }),
+      );
+
+      final result = await repository.fetchProducts();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value, isEmpty);
+    });
+
+    test('returns an empty product list when the API service fails', () async {
+      final repository = HomeRepository(const _FailingApiService());
+
+      final result = await repository.fetchProducts();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value, isEmpty);
     });
   });
 }

--- a/test/home_screen_mvp_test.dart
+++ b/test/home_screen_mvp_test.dart
@@ -1,0 +1,134 @@
+import 'package:cherry_mvp/core/config/app_images.dart';
+import 'package:cherry_mvp/core/config/app_strings.dart';
+import 'package:cherry_mvp/core/models/product.dart';
+import 'package:cherry_mvp/core/router/nav_provider.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/home/home_repository.dart';
+import 'package:cherry_mvp/features/home/home_viewmodel.dart';
+import 'package:cherry_mvp/features/home/widgets/discover_button.dart';
+import 'package:cherry_mvp/features/home/widgets/home_screen.dart';
+import 'package:cherry_mvp/features/products/product_repository.dart';
+import 'package:cherry_mvp/features/products/product_viewmodel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+class _HomeRepositoryStub implements IHomeRepository {
+  _HomeRepositoryStub(this.result);
+
+  final Result<List<Product>> result;
+
+  @override
+  Future<Result<List<Product>>> fetchProducts() async {
+    return result;
+  }
+}
+
+Future<void> _pumpHomeScreen(
+  WidgetTester tester, {
+  List<Product> products = const [],
+  Result<List<Product>>? fetchResult,
+  EdgeInsets mediaPadding = EdgeInsets.zero,
+}) async {
+  final navigator = NavigationProvider();
+  final result = fetchResult ?? Result.success(products);
+
+  await tester.pumpWidget(
+    MultiProvider(
+      providers: [
+        Provider<NavigationProvider>.value(value: navigator),
+        ChangeNotifierProvider<HomeViewModel>(
+          create: (_) => HomeViewModel(homeRepository: _HomeRepositoryStub(result)),
+        ),
+        ChangeNotifierProvider<ProductViewModel>(
+          create: (_) => ProductViewModel(
+            productRepository: ProductRepository(),
+            navigator: navigator,
+          ),
+        ),
+      ],
+      child: MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData.fromView(tester.view).copyWith(
+            padding: mediaPadding,
+          ),
+          child: const HomeScreen(),
+        ),
+      ),
+    ),
+  );
+}
+
+Product _product(int index) {
+  return Product(
+    id: 'mvp-product-$index',
+    name: 'MVP item $index',
+    description: 'Test product',
+    quality: 'Good',
+    productImages: const [AppImages.product1],
+    donation: 6,
+    price: 7,
+    securityFee: 1,
+    likes: 0,
+    number: index,
+    size: 'M',
+    postageSizeId: 'small',
+  );
+}
+
+void main() {
+  testWidgets('HomeScreen hides the global search bar for the MVP', (
+    tester,
+  ) async {
+    await _pumpHomeScreen(tester);
+
+    expect(find.text('AI Search: Red Polka Dot Dress'), findsNothing);
+    expect(find.byIcon(Icons.search), findsNothing);
+  });
+
+  testWidgets(
+    'HomeScreen keeps the discover tile below the top safe area for the MVP',
+    (tester) async {
+      await _pumpHomeScreen(
+        tester,
+        mediaPadding: const EdgeInsets.only(top: 32),
+      );
+
+      final discoverTop = tester.getTopLeft(find.byType(DiscoverButton)).dy;
+
+      expect(discoverTop, 48);
+    },
+  );
+
+  testWidgets('HomeScreen hides charity advert placeholders for the MVP', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await _pumpHomeScreen(
+      tester,
+      products: List.generate(6, (index) => _product(index + 1)),
+    );
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('MVP item 1'), findsOneWidget);
+    expect(find.text(AppStrings.adText), findsNothing);
+  });
+
+  testWidgets('HomeScreen does not show product load errors on fetch failure', (
+    tester,
+  ) async {
+    await _pumpHomeScreen(
+      tester,
+      fetchResult: Result.failure('technical failure'),
+    );
+    await tester.pump();
+
+    expect(find.text(AppStrings.failedToLoadProducts), findsNothing);
+    expect(find.text(AppStrings.noProductsAvailable), findsOneWidget);
+  });
+}


### PR DESCRIPTION
An attempt to fix https://github.com/Cherry-CIC/MVP/pull/443#pullrequestreview-4705155800 as raised by @VitaliiKoliuka.

## Summary

Frontend-only change for the home product feed.

- Updates `HomeRepository.fetchProducts()` to parse the accepted product response shapes: top-level list, `{ data: [...] }`, `{ products: [...] }`, and `{ data: { products: [...] } }`.
- Logs unsuccessful API envelopes, unexpected product response bodies, API failures, and escaped exceptions without returning a user-facing home feed error.
- Falls back to an empty product list for home feed fetch problems so the homepage does not show `Failed to load products` to customers.
- Keeps malformed individual product items as logged skips, matching the previous partial-parse behaviour.
- Adds focused `HomeRepository` tests and a `HomeScreen` regression test proving fetch failures do not render the product-load error on the homepage.

## Why

The home feed could crash or show a raw Dart type error when the products endpoint returned a wrapped or error response shape. The revised behaviour keeps those details in logs and avoids showing customers a product-load error on the homepage while the backend contract is handled separately in the backend repository.

## Scope and Review Notes

- Type of change: frontend logic and tests.
- Backend Swagger/routes/tests are intentionally out of scope because this is not the backend repository.
- Reviewers should check that showing the empty home state on product fetch failure is the intended MVP fallback.
- This does not change global error widgets or non-home product flows.

## Testing

- `flutter test test/home_repository_test.dart test/home_screen_mvp_test.dart`
- `flutter analyze`
- `flutter test` still fails on existing unrelated coverage in `test/donation_model_test.dart` because `DonationRequest.toJson()['postage_size']` is `null` rather than `medium`. This PR does not change donation models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Product loading now handles multiple API response formats.
  * Invalid, empty, or failed responses no longer show product-loading errors; the app displays an empty product state instead.
  * Individual malformed products no longer prevent valid products from loading.

* **Tests**
  * Added coverage for supported response formats, failure scenarios, and MVP home-screen behavior.
  * Verified safe-area positioning and hidden search and charity advert elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->