### PR TITLE
Implement delete account flow

### DIFF
--- a/ios/GoogleService-Info.plist
+++ b/ios/GoogleService-Info.plist
@@ -1,0 +1,36 @@
+ni ne<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>401854471349-oh11bqm8vk5i5vo8m73mf037qn9lgkoh.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.401854471349-oh11bqm8vk5i5vo8m73mf037qn9lgkoh</string>
+	<key>ANDROID_CLIENT_ID</key>
+	<string>401854471349-203slnble6n0oceoc1kg34c4tq0t1mnm.apps.googleusercontent.com</string>
+	<key>API_KEY</key>
+	<string>AIzaSyB9jkZAhIsFB-7pmtJT-x3kw7ZLBUxOuHQ</string>
+	<key>GCM_SENDER_ID</key>
+	<string>401854471349</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>uk.org.cherry.app</string>
+	<key>PROJECT_ID</key>
+	<string>cherry-mvp</string>
+	<key>STORAGE_BUCKET</key>
+	<string>cherry-mvp.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:401854471349:ios:6f29a0fb34d26a3b85f2fc</string>
+</dict>
+</plist>

--- a/ios/GoogleService-Info.plist
+++ b/ios/GoogleService-Info.plist
@@ -1,4 +1,4 @@
-ni ne<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/lib/core/utils/dependency.dart
+++ b/lib/core/utils/dependency.dart
@@ -210,6 +210,7 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
         navigator: Provider.of<NavigationProvider>(context, listen: false),
         firebaseAuth: Provider.of<FirebaseAuth>(context, listen: false),
         firestore: Provider.of<FirebaseFirestore>(context, listen: false),
+        apiService: Provider.of<ApiService>(context, listen: false),
       ),
     ),
   ];

--- a/lib/features/auth/auth_view_model.dart
+++ b/lib/features/auth/auth_view_model.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:cherry_mvp/core/models/user.dart';
 import 'package:cherry_mvp/core/router/router.dart';
+import 'package:cherry_mvp/core/services/services.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
 import 'package:cherry_mvp/features/login/login_repository.dart';
 
@@ -12,16 +15,21 @@ class AuthViewModel extends ChangeNotifier {
   final NavigationProvider navigator;
   final FirebaseAuth firebaseAuth;
   final FirebaseFirestore firestore;
+  final ApiService apiService;
 
   AuthViewModel({
     required this.loginRepository,
     required this.navigator,
     required this.firebaseAuth,
     required this.firestore,
+    required this.apiService,
   });
 
   Status _status = Status.uninitialized;
+  Status _deleteAccountStatus = Status.uninitialized;
   Status get status => _status;
+  Status get deleteAccountStatus => _deleteAccountStatus;
+  bool get isDeletingAccount => _deleteAccountStatus.type == StatusType.loading;
   User? get currentUser => firebaseAuth.currentUser;
 
   UserCredentials? userCredentials;
@@ -55,12 +63,9 @@ class AuthViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final result = await loginRepository.logout();
+      final result = await _signOutAndClearPrefs();
 
       if (result.isSuccess) {
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.clear();
-
         _status = Status.success;
         navigator.goBack();
       } else {
@@ -81,5 +86,69 @@ class AuthViewModel extends ChangeNotifier {
     } finally {
       notifyListeners();
     }
+  }
+
+  Future<Result<void>> deleteAccount() async {
+    if (isDeletingAccount) {
+      return Result.failure('Account deletion is already in progress');
+    }
+
+    _deleteAccountStatus = Status.loading;
+    notifyListeners();
+
+    try {
+      final result = await apiService.delete<Map<String, dynamic>>(
+        ApiEndpoints.deleteAccount,
+      );
+
+      if (!result.isSuccess) {
+        final message = result.error ?? 'Failed to delete account';
+        _deleteAccountStatus = Status.failure(message);
+        notifyListeners();
+        return Result.failure(message);
+      }
+
+      final response = result.value;
+      if (response != null && response['success'] == false) {
+        final message = response['message']?.toString() ?? 'Failed to delete account';
+        _deleteAccountStatus = Status.failure(message);
+        notifyListeners();
+        return Result.failure(message);
+      }
+
+      final signOutResult = await _signOutAndClearPrefs();
+      if (!signOutResult.isSuccess) {
+        final message = signOutResult.error ?? 'Account deleted, but local sign out failed';
+        _deleteAccountStatus = Status.failure(message);
+        notifyListeners();
+        return Result.failure(message);
+      }
+
+      _deleteAccountStatus = Status.success;
+      notifyListeners();
+      unawaited(
+        navigator.navigateToAndRemoveUntil(
+          AppRoutes.welcome,
+          (_) => false,
+        ),
+      );
+      return Result.success(null);
+    } catch (e) {
+      final message = 'Failed to delete account';
+      _deleteAccountStatus = Status.failure(message);
+      notifyListeners();
+      return Result.failure(message);
+    }
+  }
+
+  Future<Result<void>> _signOutAndClearPrefs() async {
+    final result = await loginRepository.logout();
+    if (!result.isSuccess) {
+      return Result.failure(result.error);
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+    return Result.success(null);
   }
 }

--- a/lib/features/auth/auth_view_model.dart
+++ b/lib/features/auth/auth_view_model.dart
@@ -116,13 +116,7 @@ class AuthViewModel extends ChangeNotifier {
         return Result.failure(message);
       }
 
-      final signOutResult = await _signOutAndClearPrefs();
-      if (!signOutResult.isSuccess) {
-        final message = signOutResult.error ?? 'Account deleted, but local sign out failed';
-        _deleteAccountStatus = Status.failure(message);
-        notifyListeners();
-        return Result.failure(message);
-      }
+      await _bestEffortSignOutAndClearPrefs();
 
       _deleteAccountStatus = Status.success;
       notifyListeners();
@@ -150,5 +144,21 @@ class AuthViewModel extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     await prefs.clear();
     return Result.success(null);
+  }
+
+  Future<void> _bestEffortSignOutAndClearPrefs() async {
+    try {
+      final result = await _signOutAndClearPrefs();
+      if (result.isSuccess) return;
+    } catch (_) {}
+
+    try {
+      await firebaseAuth.signOut();
+    } catch (_) {}
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.clear();
+    } catch (_) {}
   }
 }

--- a/lib/features/settings/widgets/settings_footer.dart
+++ b/lib/features/settings/widgets/settings_footer.dart
@@ -1,11 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cherry_mvp/core/config/config.dart';
-import 'package:cherry_mvp/core/services/services.dart';
 import 'package:cherry_mvp/features/auth/auth_view_model.dart';
 
-class SettingsFooter extends StatelessWidget {
+class SettingsFooter extends StatefulWidget {
   const SettingsFooter({super.key});
+
+  @override
+  State<SettingsFooter> createState() => _SettingsFooterState();
+}
+
+class _SettingsFooterState extends State<SettingsFooter> {
+  bool _isDeletingAccount = false;
 
   Future<bool?> _showConfirmDialog(BuildContext context) {
     return showDialog<bool>(
@@ -30,16 +36,6 @@ class SettingsFooter extends StatelessWidget {
     );
   }
 
-  Future<void> _showLoadingDialog(BuildContext context) async {
-    return showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (context) => const Center(
-        child: CircularProgressIndicator(),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return SliverList.list(
@@ -47,48 +43,29 @@ class SettingsFooter extends StatelessWidget {
         ListTile(
           title: Text(AppStrings.deleteAccountText),
           textColor: Theme.of(context).colorScheme.primary,
+          trailing: _isDeletingAccount
+              ? const SizedBox.square(
+                  dimension: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : null,
           onTap: () async {
-            // TODO: this should be handled by a view model, probably AuthViewModel, with status returned
-            // TODO: so SnackBars can be displayed
+            if (_isDeletingAccount) return;
+
             final confirm = await _showConfirmDialog(context);
             if (confirm != true) return;
+            if (!context.mounted) return;
 
-            if (context.mounted) {
-              // show loading
-              _showLoadingDialog(context);
+            setState(() => _isDeletingAccount = true);
+            final result = await context.read<AuthViewModel>().deleteAccount();
 
-              try {
-                final apiService = Provider.of<ApiService>(context, listen: false);
-                final result = await apiService.delete(ApiEndpoints.deleteAccount);
+            if (!context.mounted) return;
+            setState(() => _isDeletingAccount = false);
 
-                // Temporary: pause here if a Dart debugger is attached
-                // import dart:developer as developer at top when using this in real debug
-                // developer.debugger();
-
-                // dismiss loading
-                if (context.mounted) Navigator.of(context).pop();
-
-                if (result.isSuccess) {
-                  // On successful account deletion, log the user out and navigate to welcome
-                  if (context.mounted) {
-                    final authViewModel = Provider.of<AuthViewModel>(context, listen: false);
-                    await authViewModel.logout(context);
-                  }
-                } else {
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text(result.error ?? 'Failed to delete account')),
-                    );
-                  }
-                }
-              } catch (e) {
-                if (context.mounted) Navigator.of(context).pop();
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('Error: ${e.toString()}')),
-                  );
-                }
-              }
+            if (!result.isSuccess) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text(result.error ?? 'Failed to delete account')),
+              );
             }
           },
         ),


### PR DESCRIPTION
## Summary
- Move delete-account execution into AuthViewModel
- Call backend DELETE /api/auth/account for authenticated account deletion
- Clear local auth/preferences after successful deletion and reset navigation to Welcome
- Keep SettingsFooter focused on confirmation, loading state, and error display



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account deletion from Settings.
  * Shows inline progress feedback while an account deletion is in progress.
  * On successful deletion, automatically signs the user out and returns to the welcome screen.

* **Bug Fixes**
  * Improved deletion flow error handling with clearer user-facing failure feedback.
  * Prevented duplicate account deletion requests during an in-progress operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->