### PR TITLE
feat: add My Orders profile screen

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -25,8 +25,6 @@ subprojects {
             force( "androidx.activity:activity:1.9.3")
             force( "androidx.activity:activity-ktx:1.9.3")
             force( "androidx.activity:activity-compose:1.9.3")
-            force( "androidx.core:core:1.13.1")
-            force( "androidx.core:core-ktx:1.13.1")
             force( "androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
         }
     }

--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -64,6 +64,14 @@ class AppStrings {
   static const profileUserLiked = "Liked";
   static const profileUserListings = "Listings";
   static const profileUserBuyerDisc = "Donor discounts";
+  static const myOrdersTitle = 'My Orders';
+  static const myOrdersLoading = 'Loading your orders';
+  static const myOrdersEmpty = 'You have no orders yet.';
+  static const myOrdersLoadFailed = 'We could not load your orders. Please try again.';
+  static const myOrdersRefreshFailed = 'We could not refresh your orders.';
+  static const myOrdersStatusUnavailable = 'Status unavailable';
+  static const myOrdersPriceUnavailable = 'Price unavailable';
+  static const myOrdersSizeUnavailable = 'Size unavailable';
 
   // Profile: Donations & Activity
   static const profileUserActivityBought = 'Bought';

--- a/lib/core/services/network/api_endpoints.dart
+++ b/lib/core/services/network/api_endpoints.dart
@@ -18,6 +18,10 @@ class ApiEndpoints {
   static const String postageSizes = '$_apiPrefix/postage-sizes';
   static const String paymentIntent = '$_apiPrefix/payment/create-payment-intent';
   static const String createOrder = '$_apiPrefix/order/create';
+  static const String myOrders = '$_apiPrefix/order/my-orders';
+  static String productById(String productId) {
+    return '$products/${Uri.encodeComponent(productId)}';
+  }
 
   // Auth related
   static const String deleteAccount = '$_apiPrefix/auth/account';

--- a/lib/core/utils/dependency.dart
+++ b/lib/core/utils/dependency.dart
@@ -26,6 +26,8 @@ import 'package:cherry_mvp/features/login/login_repository.dart';
 import 'package:cherry_mvp/features/login/login_viewmodel.dart';
 import 'package:cherry_mvp/features/forgot_password/forgot_password_repository.dart';
 import 'package:cherry_mvp/features/forgot_password/forgot_password_viewmodel.dart';
+import 'package:cherry_mvp/features/orders/orders_repository.dart';
+import 'package:cherry_mvp/features/orders/orders_view_model.dart';
 import 'package:cherry_mvp/features/products/product_repository.dart';
 import 'package:cherry_mvp/features/products/product_viewmodel.dart';
 import 'package:cherry_mvp/features/register/register_repository.dart';
@@ -123,6 +125,11 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
         );
       },
     ),
+    Provider<IOrdersRepository>(
+      create: (context) => OrdersRepository(
+        Provider.of<ApiService>(context, listen: false),
+      ),
+    ),
     Provider<ICharityRepository>(
       create: (context) {
         if (useMockData) {
@@ -201,6 +208,14 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
       create: (context) => CharityViewModel(
         charityRepository: Provider.of<ICharityRepository>(context, listen: false),
         navigator: Provider.of<NavigationProvider>(context, listen: false),
+      ),
+    ),
+    ChangeNotifierProvider<OrdersViewModel>(
+      create: (context) => OrdersViewModel(
+        repository: Provider.of<IOrdersRepository>(
+          context,
+          listen: false,
+        ),
       ),
     ),
     // Logout provider

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -5,6 +5,7 @@ import 'package:cherry_mvp/features/donation/donation_page.dart';
 import 'package:cherry_mvp/features/home/widgets/bottom_nav_bar.dart';
 import 'package:cherry_mvp/features/home/widgets/home_screen.dart';
 import 'package:cherry_mvp/features/messages/message_page.dart';
+import 'package:cherry_mvp/features/orders/orders_page.dart';
 import 'package:cherry_mvp/features/profile/profile_page.dart';
 
 class HomePage extends StatefulWidget {
@@ -26,21 +27,30 @@ class _HomePageState extends State<HomePage> {
   static const int _profileNavIndex = _giveNavIndex + (FeatureFlags.showSearchNavigation ? 2 : 1);
 
   int _selectedIndex = 0;
+  bool _showOrders = false;
   final PageController _pageController = PageController();
 
-  static final List<Widget> _pages = <Widget>[
-    HomeScreen(),
-    if (FeatureFlags.showInbox) MessagePage(),
-    ProfilePage(),
-  ];
+  void _openOrders() {
+    if (!_showOrders) {
+      setState(() => _showOrders = true);
+    }
+  }
+
+  void _showProfileRoot() {
+    if (_showOrders) {
+      setState(() => _showOrders = false);
+    }
+  }
 
   void _onItemTapped(int index) {
     if (index == _homeNavIndex) {
+      _showProfileRoot();
       _pageController.jumpToPage(_homePageIndex);
       return;
     }
 
     if (FeatureFlags.showInbox && index == _inboxNavIndex) {
+      _showProfileRoot();
       _pageController.jumpToPage(_inboxPageIndex);
       return;
     }
@@ -59,6 +69,9 @@ class _HomePageState extends State<HomePage> {
     }
 
     if (index == _profileNavIndex) {
+      if (_showOrders) {
+        _showProfileRoot();
+      }
       _pageController.jumpToPage(_profilePageIndex);
     }
   }
@@ -73,6 +86,9 @@ class _HomePageState extends State<HomePage> {
 
     setState(() {
       _selectedIndex = nextSelectedIndex;
+      if (index != _profilePageIndex) {
+        _showOrders = false;
+      }
     });
   }
 
@@ -84,17 +100,41 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: PageView(
-        controller: _pageController,
-        onPageChanged: _onPageChanged,
-        children: _pages,
-      ),
-      bottomNavigationBar: CherryBottomNavBar(
-        selectedIndex: _selectedIndex,
-        onItemSelected: _onItemTapped,
-        selectedColor: Theme.of(context).colorScheme.primary,
-        unselectedColor: Theme.of(context).colorScheme.secondary,
+    return PopScope(
+      canPop: !_showOrders,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && _showOrders) {
+          _showProfileRoot();
+        }
+      },
+      child: Scaffold(
+        body: PageView(
+          controller: _pageController,
+          onPageChanged: _onPageChanged,
+          children: [
+            const HomeScreen(),
+            if (FeatureFlags.showInbox) const MessagePage(),
+            Stack(
+              fit: StackFit.expand,
+              children: [
+                Offstage(
+                  offstage: _showOrders,
+                  child: TickerMode(
+                    enabled: !_showOrders,
+                    child: ProfilePage(onOrdersPressed: _openOrders),
+                  ),
+                ),
+                if (_showOrders) MyOrdersPage(onBack: _showProfileRoot),
+              ],
+            ),
+          ],
+        ),
+        bottomNavigationBar: CherryBottomNavBar(
+          selectedIndex: _selectedIndex,
+          onItemSelected: _onItemTapped,
+          selectedColor: Theme.of(context).colorScheme.primary,
+          unselectedColor: Theme.of(context).colorScheme.secondary,
+        ),
       ),
     );
   }

--- a/lib/features/orders/models/order_summary.dart
+++ b/lib/features/orders/models/order_summary.dart
@@ -1,0 +1,121 @@
+class OrderSummary {
+  static const String fallbackCurrency = 'GBP';
+  static const String fallbackProductName = 'Item unavailable';
+
+  final String id;
+  final String productId;
+  final String productName;
+  final String imageUrl;
+  final String size;
+  final String charityLogoUrl;
+  final int? itemPriceMinor;
+  final int? totalAmountMinor;
+  final String currency;
+  final String deliveryState;
+  final String deliveryLabel;
+
+  const OrderSummary({
+    required this.id,
+    required this.productId,
+    required this.productName,
+    required this.imageUrl,
+    required this.size,
+    required this.charityLogoUrl,
+    required this.itemPriceMinor,
+    required this.totalAmountMinor,
+    required this.currency,
+    required this.deliveryState,
+    required this.deliveryLabel,
+  });
+
+  static OrderSummary? tryFromOrderJson(dynamic value) {
+    if (value is! Map) {
+      return null;
+    }
+
+    final json = Map<String, dynamic>.from(value);
+    final id = _readRequiredString(json['id']);
+    if (id == null) {
+      return null;
+    }
+
+    final productId = _readString(json['productId']);
+    final productName = _readString(json['productName']);
+
+    return OrderSummary(
+      id: id,
+      productId: productId,
+      productName: productName.isEmpty ? fallbackProductName : productName,
+      imageUrl: '',
+      size: '',
+      charityLogoUrl: '',
+      itemPriceMinor: null,
+      totalAmountMinor: _readNonNegativeInteger(json['totalAmount']),
+      currency: normaliseCurrency(json['currency']),
+      deliveryState: _readFirstString([
+        json['deliveryState'],
+        json['status'],
+      ]),
+      deliveryLabel: _readString(json['deliveryLabel']),
+    );
+  }
+
+  static String normaliseCurrency(dynamic value) {
+    final currency = _readString(value).toUpperCase();
+    return RegExp(r'^[A-Z]{3}$').hasMatch(currency) ? currency : fallbackCurrency;
+  }
+
+  OrderSummary copyWith({
+    String? productName,
+    String? imageUrl,
+    String? size,
+    String? charityLogoUrl,
+    int? itemPriceMinor,
+  }) {
+    return OrderSummary(
+      id: id,
+      productId: productId,
+      productName: productName ?? this.productName,
+      imageUrl: imageUrl ?? this.imageUrl,
+      size: size ?? this.size,
+      charityLogoUrl: charityLogoUrl ?? this.charityLogoUrl,
+      itemPriceMinor: itemPriceMinor ?? this.itemPriceMinor,
+      totalAmountMinor: totalAmountMinor,
+      currency: currency,
+      deliveryState: deliveryState,
+      deliveryLabel: deliveryLabel,
+    );
+  }
+
+  static String? _readRequiredString(dynamic value) {
+    final string = _readString(value);
+    return string.isEmpty ? null : string;
+  }
+
+  static String _readFirstString(Iterable<dynamic> values) {
+    for (final value in values) {
+      final string = _readString(value);
+      if (string.isNotEmpty) {
+        return string;
+      }
+    }
+    return '';
+  }
+
+  static String _readString(dynamic value) {
+    return value is String ? value.trim() : '';
+  }
+
+  static int? _readNonNegativeInteger(dynamic value) {
+    int? parsed;
+    if (value is int) {
+      parsed = value;
+    } else if (value is num && value.isFinite && value == value.roundToDouble()) {
+      parsed = value.toInt();
+    } else if (value is String) {
+      parsed = int.tryParse(value.trim());
+    }
+
+    return parsed != null && parsed >= 0 ? parsed : null;
+  }
+}

--- a/lib/features/orders/models/order_summary.dart
+++ b/lib/features/orders/models/order_summary.dart
@@ -49,7 +49,7 @@ class OrderSummary {
       imageUrl: '',
       size: '',
       charityLogoUrl: '',
-      itemPriceMinor: null,
+      itemPriceMinor: _readNonNegativeInteger(json['productAmount']),
       totalAmountMinor: _readNonNegativeInteger(json['totalAmount']),
       currency: normaliseCurrency(json['currency']),
       deliveryState: _readFirstString([
@@ -70,7 +70,6 @@ class OrderSummary {
     String? imageUrl,
     String? size,
     String? charityLogoUrl,
-    int? itemPriceMinor,
   }) {
     return OrderSummary(
       id: id,
@@ -79,7 +78,7 @@ class OrderSummary {
       imageUrl: imageUrl ?? this.imageUrl,
       size: size ?? this.size,
       charityLogoUrl: charityLogoUrl ?? this.charityLogoUrl,
-      itemPriceMinor: itemPriceMinor ?? this.itemPriceMinor,
+      itemPriceMinor: itemPriceMinor,
       totalAmountMinor: totalAmountMinor,
       currency: currency,
       deliveryState: deliveryState,

--- a/lib/features/orders/order_currency_formatter.dart
+++ b/lib/features/orders/order_currency_formatter.dart
@@ -5,7 +5,7 @@ class OrderCurrencyFormatter {
 
   static String? formatItemPrice(OrderSummary order) {
     final minorUnits = order.itemPriceMinor;
-    if (minorUnits == null || order.currency != 'GBP') {
+    if (minorUnits == null) {
       return null;
     }
 

--- a/lib/features/orders/order_currency_formatter.dart
+++ b/lib/features/orders/order_currency_formatter.dart
@@ -1,0 +1,28 @@
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
+
+class OrderCurrencyFormatter {
+  const OrderCurrencyFormatter._();
+
+  static String? formatItemPrice(OrderSummary order) {
+    final minorUnits = order.itemPriceMinor;
+    if (minorUnits == null || order.currency != 'GBP') {
+      return null;
+    }
+
+    return formatMinorUnits(
+      minorUnits: minorUnits,
+      currency: order.currency,
+    );
+  }
+
+  static String formatMinorUnits({
+    required int minorUnits,
+    required String currency,
+  }) {
+    final amount = (minorUnits / 100).toStringAsFixed(2);
+    if (currency == 'GBP') {
+      return '£$amount';
+    }
+    return '$currency $amount';
+  }
+}

--- a/lib/features/orders/orders_page.dart
+++ b/lib/features/orders/orders_page.dart
@@ -1,0 +1,248 @@
+import 'package:cherry_mvp/core/config/app_strings.dart';
+import 'package:cherry_mvp/core/utils/status.dart';
+import 'package:cherry_mvp/features/orders/orders_view_model.dart';
+import 'package:cherry_mvp/features/orders/widgets/order_card.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class MyOrdersPage extends StatefulWidget {
+  final VoidCallback onBack;
+
+  const MyOrdersPage({
+    super.key,
+    required this.onBack,
+  });
+
+  @override
+  State<MyOrdersPage> createState() => _MyOrdersPageState();
+}
+
+class _MyOrdersPageState extends State<MyOrdersPage> {
+  OrdersViewModel? _viewModel;
+  bool _hasInitialised = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _viewModel = context.read<OrdersViewModel>();
+
+    if (!_hasInitialised) {
+      _hasInitialised = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _viewModel?.loadOrders();
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _viewModel?.clearOrders(notify: false);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        leading: IconButton(
+          tooltip: AppStrings.back,
+          onPressed: widget.onBack,
+          icon: const Icon(Icons.arrow_back),
+        ),
+        title: Text(
+          AppStrings.myOrdersTitle,
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+      ),
+      body: SafeArea(
+        top: false,
+        child: Consumer<OrdersViewModel>(
+          builder: (context, viewModel, _) {
+            if ((viewModel.status.type == StatusType.uninitialized || viewModel.status.type == StatusType.loading) &&
+                viewModel.orders.isEmpty) {
+              return const _OrdersLoading();
+            }
+
+            if (viewModel.status.type == StatusType.failure && viewModel.orders.isEmpty) {
+              return _OrdersFailure(
+                onRetry: viewModel.retryLoad,
+              );
+            }
+
+            if (viewModel.status.type == StatusType.success && viewModel.orders.isEmpty) {
+              return _OrdersEmpty(
+                onRefresh: viewModel.refreshOrders,
+              );
+            }
+
+            return _OrdersList(viewModel: viewModel);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _OrdersLoading extends StatelessWidget {
+  const _OrdersLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: AppStrings.myOrdersLoading,
+      child: const Center(child: CircularProgressIndicator()),
+    );
+  }
+}
+
+class _OrdersFailure extends StatelessWidget {
+  final Future<void> Function() onRetry;
+
+  const _OrdersFailure({
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.receipt_long_outlined,
+              size: 48,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              AppStrings.myOrdersLoadFailed,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: onRetry,
+              child: const Text(AppStrings.retry),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OrdersEmpty extends StatelessWidget {
+  final RefreshCallback onRefresh;
+
+  const _OrdersEmpty({
+    required this.onRefresh,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.shopping_bag_outlined,
+                      size: 48,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      AppStrings.myOrdersEmpty,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OrdersList extends StatelessWidget {
+  final OrdersViewModel viewModel;
+
+  const _OrdersList({
+    required this.viewModel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final hasRefreshError = viewModel.refreshError != null;
+
+    return RefreshIndicator(
+      onRefresh: viewModel.refreshOrders,
+      child: ListView.separated(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+        itemCount: viewModel.orders.length + (hasRefreshError ? 1 : 0),
+        separatorBuilder: (_, _) => const SizedBox(height: 24),
+        itemBuilder: (context, index) {
+          if (hasRefreshError && index == 0) {
+            return _RefreshFailure(onRetry: viewModel.refreshOrders);
+          }
+
+          final orderIndex = index - (hasRefreshError ? 1 : 0);
+          return OrderCard(
+            key: ValueKey(viewModel.orders[orderIndex].id),
+            order: viewModel.orders[orderIndex],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RefreshFailure extends StatelessWidget {
+  final Future<void> Function() onRetry;
+
+  const _RefreshFailure({
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                AppStrings.myOrdersRefreshFailed,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ),
+            TextButton(
+              onPressed: onRetry,
+              child: const Text(AppStrings.retry),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/orders/orders_repository.dart
+++ b/lib/features/orders/orders_repository.dart
@@ -57,7 +57,6 @@ final class OrdersRepository implements IOrdersRepository {
               imageUrl: product.imageUrl,
               size: product.size,
               charityLogoUrl: charityLogos[product.charityId] ?? '',
-              itemPriceMinor: order.currency == 'GBP' ? product.itemPriceMinor : null,
             );
           })
           .toList(growable: false);
@@ -183,14 +182,12 @@ final class _ProductEnrichment {
   final String imageUrl;
   final String size;
   final String charityId;
-  final int? itemPriceMinor;
 
   const _ProductEnrichment({
     required this.name,
     required this.imageUrl,
     required this.size,
     required this.charityId,
-    required this.itemPriceMinor,
   });
 
   static _ProductEnrichment? tryFromJson(dynamic value) {
@@ -214,22 +211,7 @@ final class _ProductEnrichment {
       imageUrl: imageUrl,
       size: _readString(value['size']),
       charityId: _readString(value['charityId']),
-      itemPriceMinor: _majorUnitsToMinor(value['price']),
     );
-  }
-
-  static int? _majorUnitsToMinor(dynamic value) {
-    double? amount;
-    if (value is num) {
-      amount = value.toDouble();
-    } else if (value is String) {
-      amount = double.tryParse(value.trim());
-    }
-
-    if (amount == null || !amount.isFinite || amount.isNegative) {
-      return null;
-    }
-    return (amount * 100).round();
   }
 
   static String _readString(dynamic value) {

--- a/lib/features/orders/orders_repository.dart
+++ b/lib/features/orders/orders_repository.dart
@@ -1,0 +1,238 @@
+import 'package:cherry_mvp/core/services/network/api_endpoints.dart';
+import 'package:cherry_mvp/core/services/network/api_service.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
+import 'package:logging/logging.dart';
+
+abstract class IOrdersRepository {
+  Future<Result<List<OrderSummary>>> fetchOrders();
+}
+
+final class OrdersRepository implements IOrdersRepository {
+  static const int _maximumConcurrentProductRequests = 4;
+
+  final ApiService _apiService;
+  final _log = Logger('OrdersRepository');
+
+  OrdersRepository(this._apiService);
+
+  @override
+  Future<Result<List<OrderSummary>>> fetchOrders() async {
+    try {
+      final result = await _apiService.get<dynamic>(ApiEndpoints.myOrders);
+      if (!result.isSuccess || result.value == null) {
+        _log.warning('The orders request failed.');
+        return Result.failure(
+          result.error ?? 'Could not load your orders',
+        );
+      }
+
+      final rawOrders = _extractOrders(result.value);
+      if (rawOrders == null) {
+        _log.warning('The orders response did not match the documented structure.');
+        return Result.failure('Could not load your orders');
+      }
+
+      final orders = rawOrders.map(OrderSummary.tryFromOrderJson).whereType<OrderSummary>().toList(growable: false);
+      if (orders.isEmpty) {
+        return Result.success(const []);
+      }
+
+      final charityLogos = await _fetchCharityLogos();
+      final products = await _fetchProducts(
+        orders.map((order) => order.productId).where((productId) => productId.isNotEmpty).toSet(),
+      );
+
+      final enrichedOrders = orders
+          .map((order) {
+            final product = products[order.productId];
+            if (product == null) {
+              return order;
+            }
+
+            return order.copyWith(
+              productName: order.productName == OrderSummary.fallbackProductName && product.name.isNotEmpty
+                  ? product.name
+                  : order.productName,
+              imageUrl: product.imageUrl,
+              size: product.size,
+              charityLogoUrl: charityLogos[product.charityId] ?? '',
+              itemPriceMinor: order.currency == 'GBP' ? product.itemPriceMinor : null,
+            );
+          })
+          .toList(growable: false);
+
+      return Result.success(enrichedOrders);
+    } catch (_) {
+      _log.warning('The orders request could not be completed.');
+      return Result.failure('Could not load your orders');
+    }
+  }
+
+  List<dynamic>? _extractOrders(dynamic response) {
+    if (response is! Map || response['success'] == false) {
+      return null;
+    }
+
+    final data = response['data'];
+    if (data is! Map) {
+      return null;
+    }
+
+    final orders = data['orders'];
+    return orders is List ? orders : null;
+  }
+
+  Future<Map<String, String>> _fetchCharityLogos() async {
+    try {
+      final result = await _apiService.get<dynamic>(ApiEndpoints.charities);
+      if (!result.isSuccess || result.value == null) {
+        _log.warning('Charity enrichment could not be loaded.');
+        return const {};
+      }
+
+      final response = result.value;
+      if (response is! Map || response['success'] == false) {
+        _log.warning('Charity enrichment could not be parsed.');
+        return const {};
+      }
+
+      final data = response['data'];
+      if (data is! List) {
+        _log.warning('Charity enrichment could not be parsed.');
+        return const {};
+      }
+
+      final charityLogos = <String, String>{};
+      for (final value in data) {
+        if (value is! Map) {
+          continue;
+        }
+        final id = _readString(value['id']);
+        final imageUrl = _readString(value['imageUrl']);
+        if (id.isNotEmpty && imageUrl.isNotEmpty) {
+          charityLogos[id] = imageUrl;
+        }
+      }
+      return charityLogos;
+    } catch (_) {
+      _log.warning('Charity enrichment could not be completed.');
+      return const {};
+    }
+  }
+
+  Future<Map<String, _ProductEnrichment>> _fetchProducts(
+    Set<String> productIds,
+  ) async {
+    final ids = productIds.toList(growable: false);
+    final products = <String, _ProductEnrichment>{};
+    var failedProducts = 0;
+
+    for (var start = 0; start < ids.length; start += _maximumConcurrentProductRequests) {
+      final candidateEnd = start + _maximumConcurrentProductRequests;
+      final end = candidateEnd < ids.length ? candidateEnd : ids.length;
+      final batch = ids.sublist(start, end);
+      final results = await Future.wait(
+        batch.map(_fetchProduct),
+      );
+
+      for (var index = 0; index < batch.length; index++) {
+        final product = results[index];
+        if (product == null) {
+          failedProducts++;
+        } else {
+          products[batch[index]] = product;
+        }
+      }
+    }
+
+    if (failedProducts > 0) {
+      _log.warning('Some order products could not be enriched.');
+    }
+    return products;
+  }
+
+  Future<_ProductEnrichment?> _fetchProduct(String productId) async {
+    try {
+      final result = await _apiService.get<dynamic>(
+        ApiEndpoints.productById(productId),
+      );
+      if (!result.isSuccess || result.value == null) {
+        return null;
+      }
+
+      final response = result.value;
+      if (response is! Map || response['success'] == false) {
+        return null;
+      }
+
+      final data = response['data'];
+      return _ProductEnrichment.tryFromJson(data);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static String _readString(dynamic value) {
+    return value is String ? value.trim() : '';
+  }
+}
+
+final class _ProductEnrichment {
+  final String name;
+  final String imageUrl;
+  final String size;
+  final String charityId;
+  final int? itemPriceMinor;
+
+  const _ProductEnrichment({
+    required this.name,
+    required this.imageUrl,
+    required this.size,
+    required this.charityId,
+    required this.itemPriceMinor,
+  });
+
+  static _ProductEnrichment? tryFromJson(dynamic value) {
+    if (value is! Map) {
+      return null;
+    }
+
+    final rawImages = value['product_images'] ?? value['images'] ?? value['productImages'];
+    final imageUrl = rawImages is List
+        ? rawImages
+              .whereType<String>()
+              .map((url) => url.trim())
+              .firstWhere(
+                (url) => url.isNotEmpty,
+                orElse: () => '',
+              )
+        : '';
+
+    return _ProductEnrichment(
+      name: _readString(value['name']),
+      imageUrl: imageUrl,
+      size: _readString(value['size']),
+      charityId: _readString(value['charityId']),
+      itemPriceMinor: _majorUnitsToMinor(value['price']),
+    );
+  }
+
+  static int? _majorUnitsToMinor(dynamic value) {
+    double? amount;
+    if (value is num) {
+      amount = value.toDouble();
+    } else if (value is String) {
+      amount = double.tryParse(value.trim());
+    }
+
+    if (amount == null || !amount.isFinite || amount.isNegative) {
+      return null;
+    }
+    return (amount * 100).round();
+  }
+
+  static String _readString(dynamic value) {
+    return value is String ? value.trim() : '';
+  }
+}

--- a/lib/features/orders/orders_view_model.dart
+++ b/lib/features/orders/orders_view_model.dart
@@ -1,0 +1,126 @@
+import 'package:cherry_mvp/core/utils/status.dart';
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
+import 'package:cherry_mvp/features/orders/orders_repository.dart';
+import 'package:flutter/foundation.dart';
+
+class OrdersViewModel extends ChangeNotifier {
+  final IOrdersRepository repository;
+
+  OrdersViewModel({
+    required this.repository,
+  });
+
+  Status _status = Status.uninitialized;
+  List<OrderSummary> _orders = const [];
+  bool _isRefreshing = false;
+  String? _refreshError;
+  int _requestSequence = 0;
+  bool _isDisposed = false;
+
+  Status get status => _status;
+  List<OrderSummary> get orders => List.unmodifiable(_orders);
+  bool get isRefreshing => _isRefreshing;
+  String? get refreshError => _refreshError;
+
+  Future<void> loadOrders() async {
+    await _fetchOrders(clearExistingOrders: true);
+  }
+
+  Future<void> refreshOrders() async {
+    await _fetchOrders(clearExistingOrders: false);
+  }
+
+  Future<void> retryLoad() async {
+    await _fetchOrders(clearExistingOrders: true);
+  }
+
+  void clearOrders({bool notify = true}) {
+    _requestSequence++;
+    _orders = const [];
+    _status = Status.uninitialized;
+    _isRefreshing = false;
+    _refreshError = null;
+
+    if (notify) {
+      _notifyIfActive();
+    }
+  }
+
+  Future<void> _fetchOrders({
+    required bool clearExistingOrders,
+  }) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final requestId = ++_requestSequence;
+    _refreshError = null;
+
+    if (clearExistingOrders) {
+      _orders = const [];
+      _status = Status.loading;
+      _isRefreshing = false;
+    } else if (_orders.isEmpty) {
+      _status = Status.loading;
+      _isRefreshing = false;
+    } else {
+      _isRefreshing = true;
+    }
+    _notifyIfActive();
+
+    try {
+      final result = await repository.fetchOrders();
+      if (!_isCurrentRequest(requestId)) {
+        return;
+      }
+
+      if (result.isSuccess && result.value != null) {
+        _orders = List.unmodifiable(result.value!);
+        _status = Status.success;
+      } else {
+        final error = result.error ?? 'Could not load your orders';
+        if (_orders.isEmpty) {
+          _status = Status.failure(error);
+        } else {
+          _refreshError = error;
+        }
+      }
+    } catch (_) {
+      if (!_isCurrentRequest(requestId)) {
+        return;
+      }
+
+      if (_orders.isEmpty) {
+        _status = Status.failure('Could not load your orders');
+      } else {
+        _refreshError = 'Could not refresh your orders';
+      }
+    } finally {
+      if (_isCurrentRequest(requestId)) {
+        _isRefreshing = false;
+        _notifyIfActive();
+      }
+    }
+  }
+
+  bool _isCurrentRequest(int requestId) {
+    return !_isDisposed && requestId == _requestSequence;
+  }
+
+  void _notifyIfActive() {
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _requestSequence++;
+    _orders = const [];
+    _status = Status.uninitialized;
+    _isRefreshing = false;
+    _refreshError = null;
+    _isDisposed = true;
+    super.dispose();
+  }
+}

--- a/lib/features/orders/widgets/order_card.dart
+++ b/lib/features/orders/widgets/order_card.dart
@@ -1,0 +1,377 @@
+import 'package:cherry_mvp/core/config/app_strings.dart';
+import 'package:cherry_mvp/core/utils/image_provider_helper.dart';
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
+import 'package:cherry_mvp/features/orders/order_currency_formatter.dart';
+import 'package:flutter/material.dart';
+
+class OrderCard extends StatelessWidget {
+  final OrderSummary order;
+
+  const OrderCard({
+    super.key,
+    required this.order,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final priceLabel = OrderCurrencyFormatter.formatItemPrice(order) ?? AppStrings.myOrdersPriceUnavailable;
+    final statusLabel = OrderStatusFormatter.labelFor(order);
+    final sizeLabel = order.size.trim().isEmpty ? AppStrings.myOrdersSizeUnavailable : order.size.trim();
+
+    return Semantics(
+      container: true,
+      label:
+          '${order.productName}. Size $sizeLabel. '
+          '$priceLabel. $statusLabel.',
+      child: ExcludeSemantics(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final textScale = MediaQuery.textScalerOf(context).scale(1);
+            final useFlexibleLayout = constraints.maxWidth < 340 || textScale > 1.3;
+            final imageSize = useFlexibleLayout ? 112.0 : (constraints.maxWidth * 0.36).clamp(120.0, 144.0).toDouble();
+
+            if (useFlexibleLayout) {
+              return _FlexibleOrderLayout(
+                order: order,
+                imageSize: imageSize,
+                sizeLabel: sizeLabel,
+                priceLabel: priceLabel,
+                statusLabel: statusLabel,
+              );
+            }
+
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _OrderImage(order: order, size: imageSize),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(minHeight: imageSize),
+                    child: _OrderDetails(
+                      order: order,
+                      sizeLabel: sizeLabel,
+                      priceLabel: priceLabel,
+                      statusLabel: statusLabel,
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _FlexibleOrderLayout extends StatelessWidget {
+  final OrderSummary order;
+  final double imageSize;
+  final String sizeLabel;
+  final String priceLabel;
+  final String statusLabel;
+
+  const _FlexibleOrderLayout({
+    required this.order,
+    required this.imageSize,
+    required this.sizeLabel,
+    required this.priceLabel,
+    required this.statusLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _OrderImage(order: order, size: imageSize),
+            const SizedBox(width: 16),
+            Expanded(
+              child: _ProductIdentity(
+                order: order,
+                sizeLabel: sizeLabel,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(child: _PriceLabel(label: priceLabel)),
+            const SizedBox(width: 12),
+            Flexible(child: _StatusBadge(label: statusLabel)),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _OrderDetails extends StatelessWidget {
+  final OrderSummary order;
+  final String sizeLabel;
+  final String priceLabel;
+  final String statusLabel;
+
+  const _OrderDetails({
+    required this.order,
+    required this.sizeLabel,
+    required this.priceLabel,
+    required this.statusLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _ProductIdentity(order: order, sizeLabel: sizeLabel),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(child: _PriceLabel(label: priceLabel)),
+            const SizedBox(width: 8),
+            Flexible(child: _StatusBadge(label: statusLabel)),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _ProductIdentity extends StatelessWidget {
+  final OrderSummary order;
+  final String sizeLabel;
+
+  const _ProductIdentity({
+    required this.order,
+    required this.sizeLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          order.productName,
+          maxLines: 3,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+        const SizedBox(height: 2),
+        Text(
+          sizeLabel,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: order.size.trim().isEmpty
+                ? Theme.of(context).colorScheme.onSurfaceVariant
+                : Theme.of(context).colorScheme.onSurface,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PriceLabel extends StatelessWidget {
+  final String label;
+
+  const _PriceLabel({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+        fontWeight: FontWeight.w700,
+        color: label == AppStrings.myOrdersPriceUnavailable
+            ? Theme.of(context).colorScheme.onSurfaceVariant
+            : Theme.of(context).colorScheme.onSurface,
+      ),
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  final String label;
+
+  const _StatusBadge({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(minHeight: 44),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(24),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        label,
+        textAlign: TextAlign.center,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: Theme.of(context).colorScheme.onSurface,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _OrderImage extends StatelessWidget {
+  final OrderSummary order;
+  final double size;
+
+  const _OrderImage({
+    required this.order,
+    required this.size,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: size,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: Theme.of(context).colorScheme.outlineVariant,
+            width: 3,
+          ),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(7),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              _ProductImage(imageUrl: order.imageUrl),
+              Positioned(
+                left: 4,
+                bottom: 4,
+                child: _CharityLogo(imageUrl: order.charityLogoUrl),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ProductImage extends StatelessWidget {
+  final String imageUrl;
+
+  const _ProductImage({required this.imageUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    if (imageUrl.trim().isEmpty) {
+      return const _ProductImagePlaceholder();
+    }
+
+    return ImageProviderHelper.buildImage(
+      imagePath: imageUrl,
+      width: double.infinity,
+      height: double.infinity,
+      fit: BoxFit.cover,
+      errorWidget: const _ProductImagePlaceholder(),
+      loadingWidget: const Center(
+        child: SizedBox.square(
+          dimension: 24,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      ),
+    );
+  }
+}
+
+class _ProductImagePlaceholder extends StatelessWidget {
+  const _ProductImagePlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: Center(
+        child: Icon(
+          Icons.image_not_supported_outlined,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _CharityLogo extends StatelessWidget {
+  final String imageUrl;
+
+  const _CharityLogo({required this.imageUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 44,
+      height: 30,
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(5),
+        border: Border.all(
+          color: Theme.of(context).colorScheme.outlineVariant,
+        ),
+      ),
+      child: imageUrl.trim().isEmpty
+          ? Icon(
+              Icons.volunteer_activism_outlined,
+              size: 18,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            )
+          : ImageProviderHelper.buildImage(
+              imagePath: imageUrl,
+              fit: BoxFit.contain,
+              errorWidget: Icon(
+                Icons.volunteer_activism_outlined,
+                size: 18,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+    );
+  }
+}
+
+class OrderStatusFormatter {
+  const OrderStatusFormatter._();
+
+  static String labelFor(OrderSummary order) {
+    final backendLabel = order.deliveryLabel.trim();
+    if (backendLabel.isNotEmpty) {
+      return backendLabel;
+    }
+
+    final state = order.deliveryState.trim().toLowerCase().replaceAll(RegExp(r'[\s-]+'), '_');
+
+    return switch (state) {
+      'pending' || 'preparing' || 'processing' => 'Preparing',
+      'dispatched' || 'shipped' || 'in_transit' => 'On the way',
+      'out_for_delivery' => 'Out for delivery',
+      'delivered' => 'Delivered',
+      'cancelled' || 'canceled' => 'Cancelled',
+      'returned' => 'Returned',
+      'refunded' => 'Refunded',
+      _ => AppStrings.myOrdersStatusUnavailable,
+    };
+  }
+}

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -11,7 +11,12 @@ import 'package:cherry_mvp/features/profile/widgets/user_order_details.dart';
 import '../auth/auth_view_model.dart';
 
 class ProfilePage extends StatefulWidget {
-  const ProfilePage({super.key});
+  final VoidCallback? onOrdersPressed;
+
+  const ProfilePage({
+    super.key,
+    this.onOrdersPressed,
+  });
 
   @override
   State<ProfilePage> createState() => _ProfilePageState();
@@ -81,7 +86,9 @@ class _ProfilePageState extends State<ProfilePage> {
                   navigateToSettings();
                 },
               ),
-              if (FeatureFlags.showProfileShortcutCards || FeatureFlags.showDonorDiscounts) UserOrderDetails(),
+              if (FeatureFlags.showProfileShortcutCards ||
+                  FeatureFlags.showDonorDiscounts)
+                UserOrderDetails(onOrdersPressed: widget.onOrdersPressed),
               if (FeatureFlags.showImpactSummaries) ...[
                 SizedBox(height: 16),
                 DonationChart(

--- a/lib/features/profile/widgets/user_order_details.dart
+++ b/lib/features/profile/widgets/user_order_details.dart
@@ -3,8 +3,11 @@ import 'package:cherry_mvp/core/widgets/profile_user_order_details.dart';
 import 'package:flutter/material.dart';
 
 class UserOrderDetails extends StatelessWidget {
+  final VoidCallback? onOrdersPressed;
+
   const UserOrderDetails({
     super.key,
+    this.onOrdersPressed,
   });
 
   @override
@@ -19,7 +22,7 @@ class UserOrderDetails extends StatelessWidget {
                 Expanded(
                   child: UserOrderTile(
                     title: AppStrings.profileUserOrders,
-                    onPressed: () {},
+                    onPressed: onOrdersPressed ?? () {},
                     assetPath: AppImages.profileOrder,
                   ),
                 ),

--- a/test/api_endpoints_test.dart
+++ b/test/api_endpoints_test.dart
@@ -1,0 +1,15 @@
+import 'package:cherry_mvp/core/services/network/api_endpoints.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('uses the Swagger-documented My Orders route', () {
+    expect(ApiEndpoints.myOrders, '/api/order/my-orders');
+  });
+
+  test('encodes product identifiers in product detail routes', () {
+    expect(
+      ApiEndpoints.productById('product/with spaces'),
+      '/api/products/product%2Fwith%20spaces',
+    );
+  });
+}

--- a/test/home_orders_navigation_test.dart
+++ b/test/home_orders_navigation_test.dart
@@ -1,0 +1,188 @@
+import 'package:cherry_mvp/core/models/product.dart';
+import 'package:cherry_mvp/core/router/nav_provider.dart';
+import 'package:cherry_mvp/core/services/network/api_service.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/auth/auth_view_model.dart';
+import 'package:cherry_mvp/features/home/home_page.dart';
+import 'package:cherry_mvp/features/home/home_repository.dart';
+import 'package:cherry_mvp/features/home/home_viewmodel.dart';
+import 'package:cherry_mvp/features/login/login_repository.dart';
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
+import 'package:cherry_mvp/features/orders/orders_repository.dart';
+import 'package:cherry_mvp/features/orders/orders_view_model.dart';
+import 'package:cherry_mvp/features/products/product_repository.dart';
+import 'package:cherry_mvp/features/products/product_viewmodel.dart';
+import 'package:cherry_mvp/features/profile/profile_page.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+class _HomeRepositoryStub implements IHomeRepository {
+  @override
+  Future<Result<ProductPage>> fetchProducts({
+    int limit = 20,
+    String? cursor,
+    String? search,
+  }) async {
+    return Result.success(
+      const ProductPage(
+        products: <Product>[],
+        limit: 20,
+        nextCursor: null,
+        hasMore: false,
+      ),
+    );
+  }
+}
+
+class _OrdersRepositoryStub implements IOrdersRepository {
+  @override
+  Future<Result<List<OrderSummary>>> fetchOrders() async {
+    return Result.success(const []);
+  }
+}
+
+class _ApiServiceMock extends Mock implements ApiService {}
+
+class _FirebaseAuthMock extends Mock implements FirebaseAuth {}
+
+class _FirebaseFirestoreMock extends Mock implements FirebaseFirestore {}
+
+class _LoginRepositoryMock extends Mock implements LoginRepository {}
+
+Future<void> _pumpHomePage(WidgetTester tester) async {
+  final navigator = NavigationProvider();
+  final firebaseAuth = _FirebaseAuthMock();
+
+  await tester.pumpWidget(
+    MultiProvider(
+      providers: [
+        Provider<NavigationProvider>.value(value: navigator),
+        ChangeNotifierProvider(create: (_) => SearchController()),
+        ChangeNotifierProvider(
+          create: (_) => HomeViewModel(homeRepository: _HomeRepositoryStub()),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => ProductViewModel(
+            productRepository: ProductRepository(),
+            navigator: navigator,
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => OrdersViewModel(repository: _OrdersRepositoryStub()),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => AuthViewModel(
+            loginRepository: _LoginRepositoryMock(),
+            navigator: navigator,
+            firebaseAuth: firebaseAuth,
+            firestore: _FirebaseFirestoreMock(),
+            apiService: _ApiServiceMock(),
+          ),
+        ),
+      ],
+      child: const MaterialApp(home: HomePage()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openOrders(WidgetTester tester) async {
+  await tester.tap(find.text('Profile'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Orders'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('My Orders retains one bottom bar with Profile selected', (
+    tester,
+  ) async {
+    await _pumpHomePage(tester);
+    await _openOrders(tester);
+
+    expect(find.text('My Orders'), findsOneWidget);
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
+    expect(
+      tester
+          .widget<BottomNavigationBar>(find.byType(BottomNavigationBar))
+          .currentIndex,
+      2,
+    );
+  });
+
+  testWidgets('visual and system back return My Orders to Profile', (
+    tester,
+  ) async {
+    await _pumpHomePage(tester);
+    await _openOrders(tester);
+
+    await tester.tap(find.byTooltip('Back'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('My Orders'), findsNothing);
+    expect(find.text('Profile'), findsWidgets);
+
+    await tester.tap(find.text('Orders'));
+    await tester.pumpAndSettle();
+    expect(find.text('My Orders'), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.text('My Orders'), findsNothing);
+    expect(find.text('Profile'), findsWidgets);
+  });
+
+  testWidgets('leaving or re-tapping Profile resets My Orders', (tester) async {
+    await _pumpHomePage(tester);
+    await _openOrders(tester);
+
+    await tester.tap(find.text('Profile'));
+    await tester.pumpAndSettle();
+    expect(find.text('My Orders'), findsNothing);
+
+    await tester.tap(find.text('Orders'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Home'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Profile'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('My Orders'), findsNothing);
+    expect(find.text('Orders'), findsOneWidget);
+  });
+
+  testWidgets('Profile remains mounted while My Orders is visible', (
+    tester,
+  ) async {
+    await _pumpHomePage(tester);
+    await tester.tap(find.text('Profile'));
+    await tester.pumpAndSettle();
+
+    final profileFinder = find.byType(ProfilePage, skipOffstage: false);
+    final originalState = tester.state(profileFinder);
+
+    await tester.tap(find.text('Orders'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('My Orders'), findsOneWidget);
+    expect(tester.state(profileFinder), same(originalState));
+  });
+
+  testWidgets('swiping away from Profile resets My Orders', (tester) async {
+    await _pumpHomePage(tester);
+    await _openOrders(tester);
+
+    await tester.drag(find.byType(PageView), const Offset(500, 0));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Profile'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('My Orders'), findsNothing);
+    expect(find.text('Orders'), findsOneWidget);
+  });
+}

--- a/test/orders_repository_test.dart
+++ b/test/orders_repository_test.dart
@@ -39,6 +39,7 @@ void main() {
         'id': ' order-1 ',
         'productId': ' product-1 ',
         'productName': ' Shirt ',
+        'productAmount': 400,
         'totalAmount': 2599,
         'currency': ' gbp ',
         'deliveryState': ' shipped ',
@@ -49,6 +50,7 @@ void main() {
       expect(order!.id, 'order-1');
       expect(order.productId, 'product-1');
       expect(order.productName, 'Shirt');
+      expect(order.itemPriceMinor, 400);
       expect(order.totalAmountMinor, 2599);
       expect(order.currency, 'GBP');
       expect(order.deliveryState, 'shipped');
@@ -91,6 +93,7 @@ void main() {
       expect(orderWithoutProduct, isNotNull);
       expect(orderWithoutProduct!.productId, isEmpty);
       expect(orderWithoutProduct.productName, 'Purchased item');
+      expect(orderWithoutProduct.itemPriceMinor, isNull);
     });
 
     test('treats unsafe monetary values as unavailable', () {
@@ -98,15 +101,17 @@ void main() {
         _orderJson(
           id: 'order-2',
           productId: 'product-2',
+          productAmount: 12.5,
           totalAmount: 12.5,
         ),
       );
-      expect(order!.totalAmountMinor, isNull);
+      expect(order!.itemPriceMinor, isNull);
+      expect(order.totalAmountMinor, isNull);
     });
   });
 
   group('OrdersRepository', () {
-    test('uses the documented routes and enriches an order', () async {
+    test('enriches order metadata without replacing its purchase price', () async {
       final apiService = _FakeApiService((endpoint) {
         if (endpoint == ApiEndpoints.myOrders) {
           return Result.success({
@@ -117,6 +122,7 @@ void main() {
                   id: 'order-1',
                   productId: 'product-1',
                   productName: 'Purchased shirt',
+                  productAmount: 400,
                   totalAmount: 2599,
                   currency: 'gbp',
                   deliveryState: 'shipped',
@@ -167,7 +173,7 @@ void main() {
       expect(order.imageUrl, 'https://example.com/product.jpg');
       expect(order.size, 'M');
       expect(order.charityLogoUrl, 'https://example.com/charity.png');
-      expect(order.itemPriceMinor, 425);
+      expect(order.itemPriceMinor, 400);
       expect(order.totalAmountMinor, 2599);
       expect(order.currency, 'GBP');
       expect(order.deliveryState, 'shipped');
@@ -251,10 +257,10 @@ void main() {
       expect(order.productName, 'Purchased item');
       expect(order.imageUrl, isEmpty);
       expect(order.charityLogoUrl, isEmpty);
-      expect(order.itemPriceMinor, isNull);
+      expect(order.itemPriceMinor, 400);
     });
 
-    test('does not mislabel a GBP product price with another order currency', () async {
+    test('keeps the historical amount paired with its order currency', () async {
       final apiService = _FakeApiService((endpoint) {
         if (endpoint == ApiEndpoints.myOrders) {
           return Result.success({
@@ -280,7 +286,7 @@ void main() {
           'success': true,
           'data': _productJson(
             id: 'product-1',
-            price: 4,
+            price: 9,
           ),
         });
       });
@@ -290,7 +296,7 @@ void main() {
 
       expect(result.isSuccess, isTrue);
       expect(result.value!.single.currency, 'EUR');
-      expect(result.value!.single.itemPriceMinor, isNull);
+      expect(result.value!.single.itemPriceMinor, 400);
     });
 
     test('deduplicates product IDs and runs no more than four product requests', () async {
@@ -411,6 +417,7 @@ Map<String, dynamic> _orderJson({
   required String id,
   required String productId,
   String productName = 'Example shirt',
+  dynamic productAmount = 400,
   dynamic totalAmount = 2599,
   dynamic currency = 'GBP',
   dynamic deliveryState = 'preparing',
@@ -421,6 +428,7 @@ Map<String, dynamic> _orderJson({
     'id': id,
     'productId': productId,
     'productName': productName,
+    'productAmount': productAmount,
     'totalAmount': totalAmount,
     'currency': currency,
     'deliveryState': deliveryState,

--- a/test/orders_repository_test.dart
+++ b/test/orders_repository_test.dart
@@ -1,0 +1,449 @@
+import 'dart:async';
+
+import 'package:cherry_mvp/core/services/network/api_endpoints.dart';
+import 'package:cherry_mvp/core/services/network/api_service.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
+import 'package:cherry_mvp/features/orders/orders_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+typedef _GetHandler = FutureOr<Result<dynamic>> Function(String endpoint);
+
+class _FakeApiService implements ApiService {
+  final _GetHandler _handler;
+  final List<String> requestedEndpoints = [];
+
+  _FakeApiService(this._handler);
+
+  @override
+  Future<Result<T>> get<T>(
+    String endpoint, {
+    Map<String, dynamic>? queryParameters,
+  }) async {
+    requestedEndpoints.add(endpoint);
+    final result = await _handler(endpoint);
+    if (!result.isSuccess) {
+      return Result.failure(result.error);
+    }
+    return Result.success(result.value as T);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('OrderSummary', () {
+    test('parses documented order fields without converting minor units', () {
+      final order = OrderSummary.tryFromOrderJson({
+        'id': ' order-1 ',
+        'productId': ' product-1 ',
+        'productName': ' Shirt ',
+        'totalAmount': 2599,
+        'currency': ' gbp ',
+        'deliveryState': ' shipped ',
+        'deliveryLabel': ' On the way ',
+      });
+
+      expect(order, isNotNull);
+      expect(order!.id, 'order-1');
+      expect(order.productId, 'product-1');
+      expect(order.productName, 'Shirt');
+      expect(order.totalAmountMinor, 2599);
+      expect(order.currency, 'GBP');
+      expect(order.deliveryState, 'shipped');
+      expect(order.deliveryLabel, 'On the way');
+    });
+
+    test('retains valid ISO currencies and uses GBP only as a fallback', () {
+      final euroOrder = OrderSummary.tryFromOrderJson(
+        _orderJson(
+          id: 'euro-order',
+          productId: 'product-1',
+          currency: 'eur',
+        ),
+      );
+      final missingCurrencyOrder = OrderSummary.tryFromOrderJson(
+        _orderJson(
+          id: 'fallback-order',
+          productId: 'product-2',
+          currency: null,
+        ),
+      );
+
+      expect(euroOrder!.currency, 'EUR');
+      expect(missingCurrencyOrder!.currency, 'GBP');
+    });
+
+    test('rejects a missing order identifier and preserves a missing product identifier', () {
+      expect(
+        OrderSummary.tryFromOrderJson({
+          'productId': 'product-1',
+          'productName': 'Shirt',
+        }),
+        isNull,
+      );
+
+      final orderWithoutProduct = OrderSummary.tryFromOrderJson({
+        'id': 'order-without-product',
+        'productName': 'Purchased item',
+      });
+      expect(orderWithoutProduct, isNotNull);
+      expect(orderWithoutProduct!.productId, isEmpty);
+      expect(orderWithoutProduct.productName, 'Purchased item');
+    });
+
+    test('treats unsafe monetary values as unavailable', () {
+      final order = OrderSummary.tryFromOrderJson(
+        _orderJson(
+          id: 'order-2',
+          productId: 'product-2',
+          totalAmount: 12.5,
+        ),
+      );
+      expect(order!.totalAmountMinor, isNull);
+    });
+  });
+
+  group('OrdersRepository', () {
+    test('uses the documented routes and enriches an order', () async {
+      final apiService = _FakeApiService((endpoint) {
+        if (endpoint == ApiEndpoints.myOrders) {
+          return Result.success({
+            'success': true,
+            'data': {
+              'orders': [
+                _orderJson(
+                  id: 'order-1',
+                  productId: 'product-1',
+                  productName: 'Purchased shirt',
+                  totalAmount: 2599,
+                  currency: 'gbp',
+                  deliveryState: 'shipped',
+                  deliveryLabel: 'On the way',
+                ),
+              ],
+              'count': 1,
+            },
+          });
+        }
+        if (endpoint == ApiEndpoints.charities) {
+          return Result.success({
+            'success': true,
+            'data': [
+              {
+                'id': 'charity-1',
+                'imageUrl': 'https://example.com/charity.png',
+              },
+            ],
+          });
+        }
+        if (endpoint == ApiEndpoints.productById('product-1')) {
+          return Result.success({
+            'success': true,
+            'data': _productJson(
+              id: 'product-1',
+              name: 'Current shirt name',
+              price: '4.25',
+              charityId: 'charity-1',
+            ),
+          });
+        }
+        return Result.failure('Unexpected endpoint');
+      });
+      final repository = OrdersRepository(apiService);
+
+      final result = await repository.fetchOrders();
+
+      expect(result.isSuccess, isTrue);
+      expect(apiService.requestedEndpoints, [
+        ApiEndpoints.myOrders,
+        ApiEndpoints.charities,
+        ApiEndpoints.productById('product-1'),
+      ]);
+      final order = result.value!.single;
+      expect(order.id, 'order-1');
+      expect(order.productName, 'Purchased shirt');
+      expect(order.imageUrl, 'https://example.com/product.jpg');
+      expect(order.size, 'M');
+      expect(order.charityLogoUrl, 'https://example.com/charity.png');
+      expect(order.itemPriceMinor, 425);
+      expect(order.totalAmountMinor, 2599);
+      expect(order.currency, 'GBP');
+      expect(order.deliveryState, 'shipped');
+      expect(order.deliveryLabel, 'On the way');
+    });
+
+    test('keeps valid orders and tolerates malformed records', () async {
+      final apiService = _FakeApiService((endpoint) {
+        if (endpoint == ApiEndpoints.myOrders) {
+          return Result.success({
+            'success': true,
+            'data': {
+              'orders': [
+                'not an order',
+                {'id': 'missing-product'},
+                _orderJson(
+                  id: 'valid-order',
+                  productId: 'product-1',
+                  productName: '',
+                  currency: null,
+                  deliveryState: null,
+                  status: 'preparing',
+                ),
+              ],
+            },
+          });
+        }
+        if (endpoint == ApiEndpoints.charities) {
+          return Result.failure('Unavailable');
+        }
+        return Result.success({
+          'success': true,
+          'data': _productJson(
+            id: 'product-1',
+            name: 'Fallback product name',
+          ),
+        });
+      });
+      final repository = OrdersRepository(apiService);
+
+      final result = await repository.fetchOrders();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value, hasLength(2));
+      final missingProductOrder = result.value!.first;
+      expect(missingProductOrder.id, 'missing-product');
+      expect(missingProductOrder.productId, isEmpty);
+      expect(missingProductOrder.productName, OrderSummary.fallbackProductName);
+      final validOrder = result.value!.last;
+      expect(validOrder.id, 'valid-order');
+      expect(validOrder.productName, 'Fallback product name');
+      expect(validOrder.currency, 'GBP');
+      expect(validOrder.deliveryState, 'preparing');
+      expect(validOrder.charityLogoUrl, isEmpty);
+    });
+
+    test('keeps the basic order when all enrichment fails', () async {
+      final apiService = _FakeApiService((endpoint) {
+        if (endpoint == ApiEndpoints.myOrders) {
+          return Result.success({
+            'success': true,
+            'data': {
+              'orders': [
+                _orderJson(
+                  id: 'order-1',
+                  productId: 'deleted-product',
+                  productName: 'Purchased item',
+                ),
+              ],
+            },
+          });
+        }
+        return Result.failure('Unavailable');
+      });
+      final repository = OrdersRepository(apiService);
+
+      final result = await repository.fetchOrders();
+
+      expect(result.isSuccess, isTrue);
+      final order = result.value!.single;
+      expect(order.productName, 'Purchased item');
+      expect(order.imageUrl, isEmpty);
+      expect(order.charityLogoUrl, isEmpty);
+      expect(order.itemPriceMinor, isNull);
+    });
+
+    test('does not mislabel a GBP product price with another order currency', () async {
+      final apiService = _FakeApiService((endpoint) {
+        if (endpoint == ApiEndpoints.myOrders) {
+          return Result.success({
+            'success': true,
+            'data': {
+              'orders': [
+                _orderJson(
+                  id: 'euro-order',
+                  productId: 'product-1',
+                  currency: 'EUR',
+                ),
+              ],
+            },
+          });
+        }
+        if (endpoint == ApiEndpoints.charities) {
+          return Result.success({
+            'success': true,
+            'data': const [],
+          });
+        }
+        return Result.success({
+          'success': true,
+          'data': _productJson(
+            id: 'product-1',
+            price: 4,
+          ),
+        });
+      });
+      final repository = OrdersRepository(apiService);
+
+      final result = await repository.fetchOrders();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value!.single.currency, 'EUR');
+      expect(result.value!.single.itemPriceMinor, isNull);
+    });
+
+    test('deduplicates product IDs and runs no more than four product requests', () async {
+      var inFlightProductRequests = 0;
+      var maximumInFlightProductRequests = 0;
+      final apiService = _FakeApiService((endpoint) async {
+        if (endpoint == ApiEndpoints.myOrders) {
+          return Result.success({
+            'success': true,
+            'data': {
+              'orders': [
+                for (var index = 1; index <= 6; index++)
+                  _orderJson(
+                    id: 'order-$index',
+                    productId: 'product-$index',
+                  ),
+                _orderJson(
+                  id: 'duplicate-product-order',
+                  productId: 'product-1',
+                ),
+              ],
+            },
+          });
+        }
+        if (endpoint == ApiEndpoints.charities) {
+          return Result.success({
+            'success': true,
+            'data': const [],
+          });
+        }
+
+        inFlightProductRequests++;
+        if (inFlightProductRequests > maximumInFlightProductRequests) {
+          maximumInFlightProductRequests = inFlightProductRequests;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        inFlightProductRequests--;
+
+        final productId = Uri.decodeComponent(
+          endpoint.substring('${ApiEndpoints.products}/'.length),
+        );
+        return Result.success({
+          'success': true,
+          'data': _productJson(id: productId),
+        });
+      });
+      final repository = OrdersRepository(apiService);
+
+      final result = await repository.fetchOrders();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value, hasLength(7));
+      expect(maximumInFlightProductRequests, 4);
+      final productRequests = apiService.requestedEndpoints
+          .where((endpoint) => endpoint.startsWith('${ApiEndpoints.products}/'))
+          .toList();
+      expect(productRequests, hasLength(6));
+      expect(
+        productRequests.where(
+          (endpoint) => endpoint == ApiEndpoints.productById('product-1'),
+        ),
+        hasLength(1),
+      );
+    });
+
+    test('does not enrich an empty order list', () async {
+      final apiService = _FakeApiService((endpoint) {
+        return Result.success({
+          'success': true,
+          'data': {
+            'orders': const [],
+            'count': 0,
+          },
+        });
+      });
+      final repository = OrdersRepository(apiService);
+
+      final result = await repository.fetchOrders();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.value, isEmpty);
+      expect(apiService.requestedEndpoints, [ApiEndpoints.myOrders]);
+    });
+
+    test('treats main request and envelope failures as fatal', () async {
+      final failedRequest = OrdersRepository(
+        _FakeApiService(
+          (_) => Result.failure('Technical failure'),
+        ),
+      );
+      final unsuccessfulEnvelope = OrdersRepository(
+        _FakeApiService(
+          (_) => Result.success({'success': false}),
+        ),
+      );
+      final malformedEnvelope = OrdersRepository(
+        _FakeApiService(
+          (_) => Result.success({
+            'success': true,
+            'data': {'count': 1},
+          }),
+        ),
+      );
+
+      final failedResult = await failedRequest.fetchOrders();
+      final unsuccessfulResult = await unsuccessfulEnvelope.fetchOrders();
+      final malformedResult = await malformedEnvelope.fetchOrders();
+
+      expect(failedResult.isSuccess, isFalse);
+      expect(failedResult.error, 'Technical failure');
+      expect(unsuccessfulResult.isSuccess, isFalse);
+      expect(malformedResult.isSuccess, isFalse);
+    });
+  });
+}
+
+Map<String, dynamic> _orderJson({
+  required String id,
+  required String productId,
+  String productName = 'Example shirt',
+  dynamic totalAmount = 2599,
+  dynamic currency = 'GBP',
+  dynamic deliveryState = 'preparing',
+  String deliveryLabel = 'Preparing',
+  String? status,
+}) {
+  return {
+    'id': id,
+    'productId': productId,
+    'productName': productName,
+    'totalAmount': totalAmount,
+    'currency': currency,
+    'deliveryState': deliveryState,
+    'deliveryLabel': deliveryLabel,
+    'status': status,
+  };
+}
+
+Map<String, dynamic> _productJson({
+  required String id,
+  String name = 'Example shirt',
+  dynamic price = 4,
+  String charityId = 'charity-1',
+}) {
+  return {
+    'id': id,
+    'name': name,
+    'product_images': [
+      '',
+      'https://example.com/product.jpg',
+    ],
+    'price': price,
+    'size': 'M',
+    'charityId': charityId,
+  };
+}

--- a/test/orders_view_model_test.dart
+++ b/test/orders_view_model_test.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/core/utils/status.dart';
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
+import 'package:cherry_mvp/features/orders/orders_repository.dart';
+import 'package:cherry_mvp/features/orders/orders_view_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _QueuedOrdersRepository implements IOrdersRepository {
+  final List<Future<Result<List<OrderSummary>>>> responses;
+
+  _QueuedOrdersRepository(this.responses);
+
+  @override
+  Future<Result<List<OrderSummary>>> fetchOrders() {
+    return responses.removeAt(0);
+  }
+}
+
+void main() {
+  group('OrdersViewModel', () {
+    test('moves from loading to success', () async {
+      final response = Completer<Result<List<OrderSummary>>>();
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository([response.future]),
+      );
+
+      final request = viewModel.loadOrders();
+
+      expect(viewModel.status.type, StatusType.loading);
+      expect(viewModel.orders, isEmpty);
+
+      response.complete(Result.success([_order('order-1')]));
+      await request;
+
+      expect(viewModel.status.type, StatusType.success);
+      expect(viewModel.orders.single.id, 'order-1');
+      expect(viewModel.isRefreshing, isFalse);
+    });
+
+    test('represents an empty response as a successful empty state', () async {
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository([
+          Future.value(Result.success(const [])),
+        ]),
+      );
+
+      await viewModel.loadOrders();
+
+      expect(viewModel.status.type, StatusType.success);
+      expect(viewModel.orders, isEmpty);
+    });
+
+    test('exposes an initial failure and supports retry', () async {
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository([
+          Future.value(Result.failure('Technical failure')),
+          Future.value(Result.success([_order('retried-order')])),
+        ]),
+      );
+
+      await viewModel.loadOrders();
+
+      expect(viewModel.status.type, StatusType.failure);
+      expect(viewModel.status.message, 'Technical failure');
+
+      await viewModel.retryLoad();
+
+      expect(viewModel.status.type, StatusType.success);
+      expect(viewModel.orders.single.id, 'retried-order');
+    });
+
+    test('refresh preserves visible orders and then replaces them', () async {
+      final refreshResponse = Completer<Result<List<OrderSummary>>>();
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository([
+          Future.value(Result.success([_order('existing-order')])),
+          refreshResponse.future,
+        ]),
+      );
+      await viewModel.loadOrders();
+
+      final refresh = viewModel.refreshOrders();
+
+      expect(viewModel.orders.single.id, 'existing-order');
+      expect(viewModel.isRefreshing, isTrue);
+
+      refreshResponse.complete(
+        Result.success([_order('refreshed-order')]),
+      );
+      await refresh;
+
+      expect(viewModel.orders.single.id, 'refreshed-order');
+      expect(viewModel.isRefreshing, isFalse);
+      expect(viewModel.refreshError, isNull);
+    });
+
+    test('failed refresh preserves visible orders and exposes a refresh error', () async {
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository([
+          Future.value(Result.success([_order('existing-order')])),
+          Future.value(Result.failure('Technical failure')),
+        ]),
+      );
+      await viewModel.loadOrders();
+
+      await viewModel.refreshOrders();
+
+      expect(viewModel.status.type, StatusType.success);
+      expect(viewModel.orders.single.id, 'existing-order');
+      expect(viewModel.refreshError, 'Technical failure');
+      expect(viewModel.isRefreshing, isFalse);
+    });
+
+    test('a superseded response cannot replace newer orders', () async {
+      final staleResponse = Completer<Result<List<OrderSummary>>>();
+      final newerResponse = Completer<Result<List<OrderSummary>>>();
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository([
+          staleResponse.future,
+          newerResponse.future,
+        ]),
+      );
+
+      final staleRequest = viewModel.loadOrders();
+      final newerRequest = viewModel.refreshOrders();
+      newerResponse.complete(Result.success([_order('newer-order')]));
+      await newerRequest;
+      staleResponse.complete(Result.success([_order('stale-order')]));
+      await staleRequest;
+
+      expect(viewModel.status.type, StatusType.success);
+      expect(viewModel.orders.single.id, 'newer-order');
+    });
+
+    test('clearing orders prevents an in-flight response restoring account data', () async {
+      final response = Completer<Result<List<OrderSummary>>>();
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository([response.future]),
+      );
+
+      final request = viewModel.loadOrders();
+      viewModel.clearOrders(notify: false);
+      response.complete(
+        Result.success([_order('previous-account-order')]),
+      );
+      await request;
+
+      expect(viewModel.status.type, StatusType.uninitialized);
+      expect(viewModel.orders, isEmpty);
+      expect(viewModel.isRefreshing, isFalse);
+    });
+
+    test('dispose clears orders and ignores an in-flight response', () async {
+      final response = Completer<Result<List<OrderSummary>>>();
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository([response.future]),
+      );
+      var notifications = 0;
+      viewModel.addListener(() {
+        notifications++;
+      });
+
+      final request = viewModel.loadOrders();
+      expect(notifications, 1);
+      viewModel.dispose();
+      response.complete(
+        Result.success([_order('previous-account-order')]),
+      );
+      await request;
+
+      expect(viewModel.status.type, StatusType.uninitialized);
+      expect(viewModel.orders, isEmpty);
+      expect(notifications, 1);
+    });
+  });
+}
+
+OrderSummary _order(String id) {
+  return OrderSummary(
+    id: id,
+    productId: 'product-$id',
+    productName: 'Example shirt',
+    imageUrl: '',
+    size: 'M',
+    charityLogoUrl: '',
+    itemPriceMinor: 400,
+    totalAmountMinor: 600,
+    currency: 'GBP',
+    deliveryState: 'preparing',
+    deliveryLabel: 'Preparing',
+  );
+}

--- a/test/orders_widgets_test.dart
+++ b/test/orders_widgets_test.dart
@@ -1,0 +1,320 @@
+import 'package:cherry_mvp/core/config/app_strings.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
+import 'package:cherry_mvp/features/orders/order_currency_formatter.dart';
+import 'package:cherry_mvp/features/orders/orders_page.dart';
+import 'package:cherry_mvp/features/orders/orders_repository.dart';
+import 'package:cherry_mvp/features/orders/orders_view_model.dart';
+import 'package:cherry_mvp/features/orders/widgets/order_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+class _QueuedOrdersRepository implements IOrdersRepository {
+  final List<Result<List<OrderSummary>>> responses;
+  int requestCount = 0;
+
+  _QueuedOrdersRepository(this.responses);
+
+  @override
+  Future<Result<List<OrderSummary>>> fetchOrders() async {
+    requestCount++;
+    return responses.removeAt(0);
+  }
+}
+
+OrderSummary _order({
+  String id = 'order-1',
+  String productName = 'Example shirt',
+  String currency = 'GBP',
+  int? itemPriceMinor = 400,
+  String deliveryState = 'delivered',
+  String deliveryLabel = 'Delivered',
+  String imageUrl = '',
+  String charityLogoUrl = '',
+}) {
+  return OrderSummary(
+    id: id,
+    productId: 'product-1',
+    productName: productName,
+    imageUrl: imageUrl,
+    size: 'M',
+    charityLogoUrl: charityLogoUrl,
+    itemPriceMinor: itemPriceMinor,
+    totalAmountMinor: 825,
+    currency: currency,
+    deliveryState: deliveryState,
+    deliveryLabel: deliveryLabel,
+  );
+}
+
+Future<void> _pumpPage(
+  WidgetTester tester, {
+  required OrdersViewModel viewModel,
+  VoidCallback? onBack,
+}) async {
+  await tester.pumpWidget(
+    ChangeNotifierProvider.value(
+      value: viewModel,
+      child: MaterialApp(
+        home: MyOrdersPage(onBack: onBack ?? () {}),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('OrderCurrencyFormatter', () {
+    test('formats GBP minor units without widget-level currency text', () {
+      expect(
+        OrderCurrencyFormatter.formatItemPrice(_order()),
+        '£4.00',
+      );
+    });
+
+    test('does not label a GBP product price as another currency', () {
+      expect(
+        OrderCurrencyFormatter.formatItemPrice(
+          _order(currency: 'EUR'),
+        ),
+        isNull,
+      );
+    });
+
+    test('uses an ISO code for an explicitly formatted unknown currency', () {
+      expect(
+        OrderCurrencyFormatter.formatMinorUnits(
+          minorUnits: 400,
+          currency: 'ZZZ',
+        ),
+        'ZZZ 4.00',
+      );
+    });
+  });
+
+  group('OrderStatusFormatter', () {
+    test('prefers a non-empty backend delivery label', () {
+      expect(
+        OrderStatusFormatter.labelFor(
+          _order(
+            deliveryState: 'unexpected_state',
+            deliveryLabel: 'Ready to collect',
+          ),
+        ),
+        'Ready to collect',
+      );
+    });
+
+    test('maps recognised states and keeps unknown states neutral', () {
+      expect(
+        OrderStatusFormatter.labelFor(
+          _order(deliveryState: 'in_transit', deliveryLabel: ''),
+        ),
+        'On the way',
+      );
+      expect(
+        OrderStatusFormatter.labelFor(
+          _order(deliveryState: 'mystery', deliveryLabel: ''),
+        ),
+        AppStrings.myOrdersStatusUnavailable,
+      );
+    });
+  });
+
+  testWidgets('order card matches the required information hierarchy', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: OrderCard(order: _order()),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Example shirt'), findsOneWidget);
+    expect(find.text('M'), findsOneWidget);
+    expect(find.text('£4.00'), findsOneWidget);
+    expect(find.text('Delivered'), findsOneWidget);
+    expect(find.byIcon(Icons.favorite), findsNothing);
+    expect(find.byIcon(Icons.volunteer_activism_outlined), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(
+        'Example shirt. Size M. £4.00. Delivered.',
+      ),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+
+    semantics.dispose();
+  });
+
+  testWidgets('order card uses safe fallbacks for partial enrichment', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: OrderCard(
+              order: _order(
+                currency: 'EUR',
+                itemPriceMinor: null,
+                deliveryState: 'unknown',
+                deliveryLabel: '',
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(AppStrings.myOrdersPriceUnavailable), findsOneWidget);
+    expect(find.text(AppStrings.myOrdersStatusUnavailable), findsOneWidget);
+    expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.favorite), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('order card tolerates narrow screens and 200 per cent text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 700);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData.fromView(
+            tester.view,
+          ).copyWith(textScaler: const TextScaler.linear(2)),
+          child: Scaffold(
+            body: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: OrderCard(order: _order()),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Example shirt'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('long product names can grow without overflowing the image row', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(393, 852);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: OrderCard(
+              order: _order(
+                productName: 'Baggy Beige Men’s Button Shirt',
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Baggy Beige Men’s Button Shirt'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('My Orders loads orders and invokes its back callback', (
+    tester,
+  ) async {
+    var wentBack = false;
+    final repository = _QueuedOrdersRepository([
+      Result.success([_order()]),
+    ]);
+    final viewModel = OrdersViewModel(repository: repository);
+
+    await _pumpPage(
+      tester,
+      viewModel: viewModel,
+      onBack: () => wentBack = true,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(AppStrings.myOrdersTitle), findsOneWidget);
+    expect(find.text('Example shirt'), findsOneWidget);
+    expect(repository.requestCount, 1);
+
+    await tester.tap(find.byTooltip(AppStrings.back));
+    expect(wentBack, isTrue);
+  });
+
+  testWidgets('My Orders shows an empty state after a successful load', (
+    tester,
+  ) async {
+    final viewModel = OrdersViewModel(
+      repository: _QueuedOrdersRepository([
+        Result.success(const []),
+      ]),
+    );
+
+    await _pumpPage(tester, viewModel: viewModel);
+    await tester.pumpAndSettle();
+
+    expect(find.text(AppStrings.myOrdersEmpty), findsOneWidget);
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+  });
+
+  testWidgets('My Orders supports retry after an initial failure', (
+    tester,
+  ) async {
+    final repository = _QueuedOrdersRepository([
+      Result.failure('technical failure'),
+      Result.success([_order()]),
+    ]);
+    final viewModel = OrdersViewModel(repository: repository);
+
+    await _pumpPage(tester, viewModel: viewModel);
+    await tester.pumpAndSettle();
+
+    expect(find.text(AppStrings.myOrdersLoadFailed), findsOneWidget);
+    expect(find.text(AppStrings.retry), findsOneWidget);
+
+    await tester.tap(find.text(AppStrings.retry));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Example shirt'), findsOneWidget);
+    expect(repository.requestCount, 2);
+  });
+
+  testWidgets('disposing My Orders clears cached account data', (
+    tester,
+  ) async {
+    final viewModel = OrdersViewModel(
+      repository: _QueuedOrdersRepository([
+        Result.success([_order()]),
+      ]),
+    );
+
+    await _pumpPage(tester, viewModel: viewModel);
+    await tester.pumpAndSettle();
+    expect(viewModel.orders, isNotEmpty);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+    expect(viewModel.orders, isEmpty);
+  });
+}

--- a/test/orders_widgets_test.dart
+++ b/test/orders_widgets_test.dart
@@ -73,12 +73,12 @@ void main() {
       );
     });
 
-    test('does not label a GBP product price as another currency', () {
+    test('formats a trusted non-GBP order amount with its ISO code', () {
       expect(
         OrderCurrencyFormatter.formatItemPrice(
           _order(currency: 'EUR'),
         ),
-        isNull,
+        'EUR 4.00',
       );
     });
 


### PR DESCRIPTION
In summary:

<img width="614" height="1328" alt="image" src="https://github.com/user-attachments/assets/47f4f63e-4482-4d5c-a1dc-713180408b3e" />

- Added the My Orders Profile subpage with loading, empty, error, refresh and order-list states.
- Used the existing authenticated API client with the Swagger-documented `GET /api/order/my-orders` route.
- Enriched unique products with bounded concurrency and safe partial-failure fallbacks.
- Preserved monetary values as integer minor units and formatted item prices using the order currency.
- Centralised delivery-status labels with a neutral fallback for unknown states.
- Kept the existing bottom navigation visible with Profile selected, including visual and system back handling.
- Removed the like badge and count following the latest product decision, superseding that detail in the original issue brief.

## Scope

Frontend only. No backend, Firestore or Swagger changes are included.

## Validation

- 39 focused endpoint, repository, view-model, widget and navigation tests passed.
- Targeted Flutter analysis passed with no issues.
- The staged diff was checked for whitespace errors and contains only My Orders work.

Closes #451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “My Orders” experience accessible from Profile, with loading, empty, error, retry, and pull-to-refresh states.
  * Orders now display product details, prices, delivery statuses, and charity branding.
  * Added consistent currency formatting and clear unavailable-value messaging.
* **Bug Fixes**
  * Improved navigation and back-button handling between Profile and “My Orders”.
  * Preserved the original order price when product information is refreshed.
* **Tests**
  * Expanded coverage for navigation, loading states, formatting, rendering, and order data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->