### PR TITLE
Exclude seller listings and prevent self-purchase

### DIFF
--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -195,6 +195,7 @@ class AppStrings {
   static const productPageRequestOtherCharity = 'Request other charity';
   static const productPageMakeOffer = 'Make Offer';
   static const productPageBuyNow = 'Buy Now';
+  static const productPageYourListing = 'Your listing';
   static const giveInStyle = 'Give in style';
   static const productIncl = 'Incl.';
   static const askSeller = 'Ask seller';
@@ -243,6 +244,7 @@ class AppStrings {
   static const checkoutMobilePhoneRequired = 'A mobile phone number is required for InPost pickup';
   static const checkoutPickupPostcodeRequired = 'Please enter a postcode';
   static const checkoutPickupPostcodeInvalid = 'Please enter a valid UK postcode';
+  static const checkoutOwnProductNotAllowed = 'You cannot buy your own listing.';
 
   // Card Details
   static const cardDetailsTitle = 'Card Details';

--- a/lib/core/utils/dependency.dart
+++ b/lib/core/utils/dependency.dart
@@ -82,11 +82,18 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
     ChangeNotifierProvider(create: (_) => SearchController()),
     Provider<IHomeRepository>(
       create: (context) {
+        final firebaseAuth = Provider.of<FirebaseAuth>(
+          context,
+          listen: false,
+        );
         if (useMockData) {
-          return HomeRepositoryMock();
+          return HomeRepositoryMock(
+            currentUserIdProvider: () => firebaseAuth.currentUser?.uid,
+          );
         } else {
           return HomeRepository(
             Provider.of<ApiService>(context, listen: false),
+            currentUserIdProvider: () => firebaseAuth.currentUser?.uid,
           );
         }
       },
@@ -195,6 +202,8 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
         checkoutRepository: Provider.of<ICheckoutRepository>(context, listen: false),
         navigator: Provider.of<NavigationProvider>(context, listen: false),
         donationRepository: Provider.of<IDonationRepository>(context, listen: false),
+        currentUserIdProvider: () =>
+            Provider.of<FirebaseAuth>(context, listen: false).currentUser?.uid,
       ),
     ),
     ChangeNotifierProvider<CharityViewModel>(

--- a/lib/features/checkout/checkout_view_model.dart
+++ b/lib/features/checkout/checkout_view_model.dart
@@ -23,9 +23,15 @@ class CheckoutViewModel extends ChangeNotifier {
   final ICheckoutRepository checkoutRepository;
   final IDonationRepository _donationRepository;
   final NavigationProvider navigator;
+  final String? Function() _currentUserIdProvider;
   final _log = Logger('CheckoutViewModel');
 
-  CheckoutViewModel({required this._donationRepository, required this.checkoutRepository, required this.navigator});
+  CheckoutViewModel({
+    required this._donationRepository,
+    required this.checkoutRepository,
+    required this.navigator,
+    String? Function()? currentUserIdProvider,
+  }) : _currentUserIdProvider = currentUserIdProvider ?? (() => null);
 
   Status _status = Status.uninitialized;
 
@@ -142,7 +148,8 @@ class CheckoutViewModel extends ChangeNotifier {
   bool get hasPaymentMethod => _selectedPaymentType != null || _hasPaymentMethod;
 
   /// Whether the order is ready for checkout (has both address and payment method)
-  bool get canCheckout => hasShippingAddress && hasPaymentMethod;
+  bool get canCheckout =>
+      hasShippingAddress && hasPaymentMethod && !_containsOwnProduct;
 
   void setAddressConfirmed(bool value) {
     isShippingAddressConfirmed = value;
@@ -150,9 +157,14 @@ class CheckoutViewModel extends ChangeNotifier {
   }
 
   // Existing basket methods
-  void addItem(Product product) {
+  bool addItem(Product product) {
+    if (isOwnProduct(product)) {
+      return false;
+    }
+
     _basketItems.add(product);
     notifyListeners();
+    return true;
   }
 
   void removeItem(Product product) {
@@ -164,6 +176,18 @@ class CheckoutViewModel extends ChangeNotifier {
     _basketItems.clear();
     notifyListeners();
   }
+
+  bool isOwnProduct(Product product) {
+    final currentUserId = _currentUserIdProvider()?.trim();
+    final sellerId = product.userId?.trim();
+    return currentUserId != null &&
+        currentUserId.isNotEmpty &&
+        sellerId != null &&
+        sellerId.isNotEmpty &&
+        sellerId == currentUserId;
+  }
+
+  bool get _containsOwnProduct => _basketItems.any(isOwnProduct);
 
   // Shipping address methods
 
@@ -496,6 +520,20 @@ class CheckoutViewModel extends ChangeNotifier {
   // }
 
   Future<bool> payWithPaymentSheet() async {
+    if (basketItems.isEmpty) {
+      _createOrderStatus = Status.failure('Your basket is empty');
+      notifyListeners();
+      return false;
+    }
+
+    if (_containsOwnProduct) {
+      _createOrderStatus = Status.failure(
+        AppStrings.checkoutOwnProductNotAllowed,
+      );
+      notifyListeners();
+      return false;
+    }
+
     if (_selectedPaymentType == null) {
       _createOrderStatus = Status.failure(
         AppStrings.checkoutPaymentMethodRequired,
@@ -587,6 +625,14 @@ class CheckoutViewModel extends ChangeNotifier {
 
     if (basketItems.isEmpty) {
       _createOrderStatus = Status.failure('Your basket is empty');
+      notifyListeners();
+      return;
+    }
+
+    if (_containsOwnProduct) {
+      _createOrderStatus = Status.failure(
+        AppStrings.checkoutOwnProductNotAllowed,
+      );
       notifyListeners();
       return;
     }

--- a/lib/features/home/home_repository.dart
+++ b/lib/features/home/home_repository.dart
@@ -29,9 +29,13 @@ final class ProductPage {
 
 final class HomeRepository implements IHomeRepository {
   final ApiService _apiService;
+  final String? Function() _currentUserIdProvider;
   final _log = Logger('HomeRepository');
 
-  HomeRepository(this._apiService);
+  HomeRepository(
+    this._apiService, {
+    String? Function()? currentUserIdProvider,
+  }) : _currentUserIdProvider = currentUserIdProvider ?? (() => null);
 
   @override
   Future<Result<ProductPage>> fetchProducts({
@@ -80,7 +84,10 @@ final class HomeRepository implements IHomeRepository {
         final meta = _extractMeta(data);
         return Result.success(
           ProductPage(
-            products: products,
+            products: excludeCurrentSellerProducts(
+              products,
+              _currentUserIdProvider(),
+            ),
             limit: meta.limit ?? limit,
             nextCursor: meta.nextCursor,
             hasMore: meta.hasMore,
@@ -155,6 +162,12 @@ final class HomeRepository implements IHomeRepository {
 }
 
 final class HomeRepositoryMock implements IHomeRepository {
+  final String? Function() _currentUserIdProvider;
+
+  HomeRepositoryMock({
+    String? Function()? currentUserIdProvider,
+  }) : _currentUserIdProvider = currentUserIdProvider ?? (() => null);
+
   @override
   Future<Result<ProductPage>> fetchProducts({
     int limit = 20,
@@ -163,13 +176,30 @@ final class HomeRepositoryMock implements IHomeRepository {
   }) async {
     return Result.success(
       ProductPage(
-        products: dummyProducts.take(limit).toList(),
+        products: excludeCurrentSellerProducts(
+          dummyProducts,
+          _currentUserIdProvider(),
+        ).take(limit).toList(),
         limit: limit,
         nextCursor: null,
         hasMore: false,
       ),
     );
   }
+}
+
+List<Product> excludeCurrentSellerProducts(
+  Iterable<Product> products,
+  String? currentUserId,
+) {
+  final normalizedUserId = currentUserId?.trim();
+  if (normalizedUserId == null || normalizedUserId.isEmpty) {
+    return products.toList();
+  }
+
+  return products
+      .where((product) => product.userId?.trim() != normalizedUserId)
+      .toList();
 }
 
 final class _ProductMeta {

--- a/lib/features/products/product_page.dart
+++ b/lib/features/products/product_page.dart
@@ -31,6 +31,8 @@ class ProductPage extends StatelessWidget {
     }
 
     const hasOptionalProductHighlights = FeatureFlags.showDonorDiscounts || FeatureFlags.showOtherCharityRequests;
+    final checkoutViewModel = context.watch<CheckoutViewModel>();
+    final isOwnListing = checkoutViewModel.isOwnProduct(product);
 
     return Scaffold(
       body: CustomScrollView(
@@ -139,14 +141,23 @@ class ProductPage extends StatelessWidget {
                       child: SizedBox(
                         height: 56,
                         child: FilledButton(
-                          onPressed: () {
-                            context.read<CheckoutViewModel>().clearBasket();
-                            context.read<CheckoutViewModel>().addItem(product);
-                            context.read<NavigationProvider>().navigateTo(
-                              AppRoutes.checkout,
-                            );
-                          },
-                          child: Text(AppStrings.productPageBuyNow, textAlign: TextAlign.center),
+                          onPressed: isOwnListing
+                              ? null
+                              : () {
+                                  checkoutViewModel.clearBasket();
+                                  if (!checkoutViewModel.addItem(product)) {
+                                    return;
+                                  }
+                                  context.read<NavigationProvider>().navigateTo(
+                                    AppRoutes.checkout,
+                                  );
+                                },
+                          child: Text(
+                            isOwnListing
+                                ? AppStrings.productPageYourListing
+                                : AppStrings.productPageBuyNow,
+                            textAlign: TextAlign.center,
+                          ),
                         ),
                       ),
                     ),

--- a/test/checkout_view_model_test.dart
+++ b/test/checkout_view_model_test.dart
@@ -1,4 +1,6 @@
 import 'package:cherry_mvp/core/router/nav_provider.dart';
+import 'package:cherry_mvp/core/config/app_strings.dart';
+import 'package:cherry_mvp/core/models/product.dart';
 import 'package:cherry_mvp/features/donation/donation_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -56,6 +58,42 @@ void main() {
       expect(viewModel.hasPaymentMethod, false);
       expect(viewModel.canCheckout, false);
       expect(viewModel.nearestInposts, isEmpty);
+    });
+
+    test('should reject an item owned by the signed-in user', () {
+      viewModel = CheckoutViewModel(
+        checkoutRepository: FakeCheckoutRepository(),
+        navigator: mockNavigator,
+        donationRepository: FakeDonationRepository(),
+        currentUserIdProvider: () => 'seller-1',
+      );
+      final product = _product(userId: 'seller-1');
+
+      final added = viewModel.addItem(product);
+
+      expect(added, isFalse);
+      expect(viewModel.basketItems, isEmpty);
+      expect(viewModel.isOwnProduct(product), isTrue);
+    });
+
+    test('should stop checkout if an owned item is already in the basket', () async {
+      var currentUserId = 'buyer-1';
+      viewModel = CheckoutViewModel(
+        checkoutRepository: FakeCheckoutRepository(),
+        navigator: mockNavigator,
+        donationRepository: FakeDonationRepository(),
+        currentUserIdProvider: () => currentUserId,
+      );
+      viewModel.addItem(_product(userId: 'seller-1'));
+      currentUserId = 'seller-1';
+
+      final paid = await viewModel.payWithPaymentSheet();
+
+      expect(paid, isFalse);
+      expect(
+        viewModel.createOrderStatus.message,
+        AppStrings.checkoutOwnProductNotAllowed,
+      );
     });
 
     test('should set shipping address correctly', () {
@@ -277,4 +315,22 @@ void main() {
       expect(viewModel.nearestInposts.first.inpost.name, 'InPost');
     });
   });
+}
+
+Product _product({required String userId}) {
+  return Product(
+    id: 'product-1',
+    userId: userId,
+    name: 'Jumper',
+    description: 'Blue jumper',
+    quality: 'Good',
+    productImages: const ['https://example.com/jumper.jpg'],
+    donation: 20,
+    price: 20,
+    securityFee: 2,
+    likes: 0,
+    number: 1,
+    size: 'M',
+    postageSizeId: 'small',
+  );
 }

--- a/test/home_repository_test.dart
+++ b/test/home_repository_test.dart
@@ -167,12 +167,33 @@ void main() {
 
       expect(apiService.lastQueryParameters, {'limit': 10});
     });
+
+    test('excludes products owned by the signed-in seller', () async {
+      final repository = HomeRepository(
+        _FakeApiService([
+          _productJson(id: 'own-product', userId: 'seller-1'),
+          _productJson(id: 'other-product', userId: 'seller-2'),
+        ]),
+        currentUserIdProvider: () => 'seller-1',
+      );
+
+      final result = await repository.fetchProducts();
+
+      expect(
+        result.value!.products.map((product) => product.id),
+        ['other-product'],
+      );
+    });
   });
 }
 
-Map<String, dynamic> _productJson({required String id}) {
+Map<String, dynamic> _productJson({
+  required String id,
+  String? userId,
+}) {
   return {
     'id': id,
+    'userId': ?userId,
     'name': 'Jumper',
     'description': 'Blue jumper',
     'quality': 'GOOD',

--- a/test/product_self_purchase_test.dart
+++ b/test/product_self_purchase_test.dart
@@ -1,0 +1,86 @@
+import 'package:cherry_mvp/core/config/app_images.dart';
+import 'package:cherry_mvp/core/config/app_strings.dart';
+import 'package:cherry_mvp/core/models/product.dart';
+import 'package:cherry_mvp/core/router/nav_provider.dart';
+import 'package:cherry_mvp/features/checkout/checkout_repository.dart';
+import 'package:cherry_mvp/features/checkout/checkout_view_model.dart';
+import 'package:cherry_mvp/features/donation/donation_repository.dart';
+import 'package:cherry_mvp/features/products/product_page.dart';
+import 'package:cherry_mvp/features/products/product_repository.dart';
+import 'package:cherry_mvp/features/products/product_viewmodel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _CheckoutRepositoryStub implements ICheckoutRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _DonationRepositoryStub implements IDonationRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  testWidgets('ProductPage disables purchase for the signed-in seller', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    tester.view.physicalSize = const Size(900, 2200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final navigator = NavigationProvider();
+    final productViewModel = ProductViewModel(
+      productRepository: ProductRepository(),
+      navigator: navigator,
+    )..setProduct(_product);
+    final checkoutViewModel = CheckoutViewModel(
+      donationRepository: _DonationRepositoryStub(),
+      checkoutRepository: _CheckoutRepositoryStub(),
+      navigator: navigator,
+      currentUserIdProvider: () => 'seller-1',
+    );
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          Provider<NavigationProvider>.value(value: navigator),
+          ChangeNotifierProvider<ProductViewModel>.value(
+            value: productViewModel,
+          ),
+          ChangeNotifierProvider<CheckoutViewModel>.value(
+            value: checkoutViewModel,
+          ),
+        ],
+        child: const MaterialApp(home: ProductPage()),
+      ),
+    );
+    await tester.pump();
+
+    final button = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, AppStrings.productPageYourListing),
+    );
+    expect(button.onPressed, isNull);
+    expect(checkoutViewModel.basketItems, isEmpty);
+  });
+}
+
+const _product = Product(
+  id: 'product-1',
+  userId: 'seller-1',
+  name: 'Jumper',
+  description: 'Blue jumper',
+  quality: 'Good',
+  productImages: [AppImages.product1],
+  donation: 20,
+  price: 20,
+  securityFee: 2,
+  likes: 0,
+  number: 1,
+  size: 'M',
+  postageSizeId: 'small',
+);


### PR DESCRIPTION
Fixes: https://github.com/Cherry-CIC/MVP/issues/467

Ensuring users cannot see their own items on the homepage (only under their listings) and subsequently they cannot purchase their own items.

## What changed

- apply one central signed-in seller exclusion in `HomeRepository`, covering initial load, refresh, pagination, search and search pagination
- apply the same exclusion to mock feed data
- disable Buy Now on the seller's own product page and label it `Your listing`
- prevent owned products entering the basket and re-check before payment and order creation
- add focused repository, view-model and widget coverage

## Why

Every homepage feed path converged on the same repository but no ownership exclusion was applied. The product and checkout screens also allowed a signed-in seller to start checkout for their own listing.

## Impact

Signed-in sellers no longer see their listings in homepage feeds. If an owned product reaches the product or checkout flow through stale state or another route, the app still refuses the purchase.

## Checks

- focused feed, homepage, checkout, product-page, payment and endpoint tests (29 tests passed in the current MVP workspace; 27 on clean `main`)
- `flutter analyze` (no issues)
- `git diff --check`

The full clean-`main` Flutter suite was also run. It has two unrelated existing failures in `donation_model_test.dart` and `settings_legal_information_test.dart`; all tests in this change pass.

## Backend enforcement

Depends on Cherry-CIC/cherry-Backend#39 for trusted feed filtering and server-side self-purchase prevention.