### PR TITLE
Keep API-backed like counts and liked state consistent

### DIFF
--- a/lib/core/utils/dependency.dart
+++ b/lib/core/utils/dependency.dart
@@ -163,10 +163,23 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
         navigator: Provider.of<NavigationProvider>(context, listen: false),
       ),
     ),
-    ChangeNotifierProvider<HomeViewModel>(
-      create: (context) => HomeViewModel(
-        homeRepository: Provider.of<IHomeRepository>(context, listen: false),
+    ChangeNotifierProvider<ProductViewModel>(
+      create: (context) => ProductViewModel(
+        productRepository: Provider.of<ProductRepository>(context, listen: false),
+        navigator: Provider.of<NavigationProvider>(context, listen: false),
       ),
+    ),
+    ChangeNotifierProvider<HomeViewModel>(
+      create: (context) {
+        final productViewModel = Provider.of<ProductViewModel>(
+          context,
+          listen: false,
+        );
+        return HomeViewModel(
+          homeRepository: Provider.of<IHomeRepository>(context, listen: false),
+          onProductsLoaded: productViewModel.reconcileProductCounts,
+        );
+      },
     ),
     Provider<SearchRepository>(create: (context) => SearchRepository()),
     ChangeNotifierProvider<SearchViewModel>(
@@ -180,12 +193,6 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
           context,
           listen: false,
         ),
-      ),
-    ),
-    ChangeNotifierProvider<ProductViewModel>(
-      create: (context) => ProductViewModel(
-        productRepository: Provider.of<ProductRepository>(context, listen: false),
-        navigator: Provider.of<NavigationProvider>(context, listen: false),
       ),
     ),
     ChangeNotifierProvider<DonationViewModel>(

--- a/lib/features/home/home_viewmodel.dart
+++ b/lib/features/home/home_viewmodel.dart
@@ -13,8 +13,9 @@ class HomeViewModel extends ChangeNotifier {
 
   final _log = Logger('HomeViewModel');
   final IHomeRepository homeRepository;
+  final void Function(Iterable<Product>)? onProductsLoaded;
 
-  HomeViewModel({required this.homeRepository});
+  HomeViewModel({required this.homeRepository, this.onProductsLoaded});
 
   // Private variables
   Status _status = Status.uninitialized;
@@ -125,6 +126,7 @@ class HomeViewModel extends ChangeNotifier {
         final existingIds = _homeProducts.map((product) => product.id).toSet();
         final newProducts = page.products.where((product) => !existingIds.contains(product.id));
         _homeProducts = [..._homeProducts, ...newProducts];
+        onProductsLoaded?.call(page.products);
         _nextCursor = page.nextCursor;
         _hasMore = page.hasMore;
         _homeLoadMoreRetryAt = null;
@@ -168,6 +170,7 @@ class HomeViewModel extends ChangeNotifier {
         final existingIds = _searchProducts.map((product) => product.id).toSet();
         final newProducts = page.products.where((product) => !existingIds.contains(product.id));
         _searchProducts = [..._searchProducts, ...newProducts];
+        onProductsLoaded?.call(page.products);
         _searchNextCursor = page.nextCursor;
         _searchHasMore = page.hasMore;
       } else {
@@ -211,6 +214,7 @@ class HomeViewModel extends ChangeNotifier {
         }
         final page = result.value!;
         _homeProducts = page.products;
+        onProductsLoaded?.call(page.products);
         _nextCursor = page.nextCursor;
         _hasMore = page.hasMore;
         _status = Status.success;
@@ -270,6 +274,7 @@ class HomeViewModel extends ChangeNotifier {
         }
         final page = result.value!;
         _searchProducts = page.products;
+        onProductsLoaded?.call(page.products);
         _searchNextCursor = page.nextCursor;
         _searchHasMore = page.hasMore;
         _searchStatus = Status.success;

--- a/lib/features/home/widgets/dashboard.dart
+++ b/lib/features/home/widgets/dashboard.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cherry_mvp/core/config/feature_flags.dart';
@@ -32,7 +34,14 @@ class _DashboardPageState extends State<DashboardPage> {
       _hasInitialized = true;
 
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        context.read<HomeViewModel>().fetchProducts();
+        if (!mounted) {
+          return;
+        }
+
+        unawaited(
+          context.read<ProductViewModel>().hydrateLikedProducts(),
+        );
+        unawaited(context.read<HomeViewModel>().fetchProducts());
       });
     }
   }

--- a/lib/features/products/product_repository.dart
+++ b/lib/features/products/product_repository.dart
@@ -3,6 +3,13 @@ import 'package:cherry_mvp/core/services/network/api_endpoints.dart';
 import 'package:cherry_mvp/core/services/network/api_service.dart';
 import 'package:cherry_mvp/core/utils/result.dart';
 
+final class ProductLikeUpdate {
+  const ProductLikeUpdate({required this.liked, required this.likes});
+
+  final bool liked;
+  final int likes;
+}
+
 class ProductRepository {
   ProductRepository(this._apiService);
 
@@ -11,11 +18,11 @@ class ProductRepository {
 
   final ApiService _apiService;
 
-  Future<Result<void>> likeProduct(Product product) async {
+  Future<Result<ProductLikeUpdate>> likeProduct(Product product) async {
     return _setProductLiked(product.id, liked: true);
   }
 
-  Future<Result<void>> unlikeProduct(String productId) async {
+  Future<Result<ProductLikeUpdate>> unlikeProduct(String productId) async {
     return _setProductLiked(productId, liked: false);
   }
 
@@ -65,7 +72,7 @@ class ProductRepository {
     }
   }
 
-  Future<Result<void>> _setProductLiked(
+  Future<Result<ProductLikeUpdate>> _setProductLiked(
     String productId, {
     required bool liked,
   }) async {
@@ -97,10 +104,25 @@ class ProductRepository {
         return Result.failure(failureMessage);
       }
 
-      return Result.success(null);
+      final likes = _parseLikeCount(responseData['likes']);
+      if (likes == null) {
+        return Result.failure(failureMessage);
+      }
+
+      return Result.success(ProductLikeUpdate(liked: liked, likes: likes));
     } catch (_) {
       return Result.failure(failureMessage);
     }
+  }
+
+  int? _parseLikeCount(dynamic value) {
+    final likes = switch (value) {
+      int() => value,
+      String() => int.tryParse(value),
+      _ => null,
+    };
+
+    return likes != null && likes >= 0 ? likes : null;
   }
 
   bool _isUnsuccessfulResponse(dynamic response) {

--- a/lib/features/products/product_viewmodel.dart
+++ b/lib/features/products/product_viewmodel.dart
@@ -11,6 +11,7 @@ class ProductViewModel extends ChangeNotifier {
   // Centralized tracker: Map<ProductID, IsLiked>
   final Map<String, bool> _likedProducts = {};
   final Map<String, Product> _likedProductCache = {};
+  final Map<String, int> _likeCountOverrides = {};
   final Set<String> _pendingLikeUpdates = {};
 
   Product? get product => _product;
@@ -41,8 +42,7 @@ class ProductViewModel extends ChangeNotifier {
 
   // Get dynamic count for a product
   int getLikesCount(Product product) {
-    bool isLiked = _likedProducts[product.id] ?? false;
-    return product.likes + (isLiked ? 1 : 0);
+    return _likeCountOverrides[product.id] ?? product.likes;
   }
 
   void setProduct(Product product) {
@@ -70,15 +70,17 @@ class ProductViewModel extends ChangeNotifier {
 
     _pendingLikeUpdates.remove(id);
 
-    if (result.isSuccess) {
-      _likedProducts[id] = liked;
-      if (liked) {
+    final update = result.value;
+    if (result.isSuccess && update != null && update.liked == liked) {
+      _likedProducts[id] = update.liked;
+      _likeCountOverrides[id] = update.likes;
+      if (update.liked) {
         _likedProductCache[id] = product;
       } else {
         _likedProductCache.remove(id);
       }
       notifyListeners();
-      return Result.success(liked);
+      return Result.success(update.liked);
     }
 
     notifyListeners();
@@ -112,6 +114,25 @@ class ProductViewModel extends ChangeNotifier {
 
       if (_likedProductCache[product.id] != product) {
         _likedProductCache[product.id] = product;
+        changed = true;
+      }
+
+      if (_likeCountOverrides[product.id] != product.likes) {
+        _likeCountOverrides[product.id] = product.likes;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      notifyListeners();
+    }
+  }
+
+  void reconcileProductCounts(Iterable<Product> products) {
+    var changed = false;
+
+    for (final product in products) {
+      if (_likeCountOverrides.remove(product.id) != null) {
         changed = true;
       }
     }

--- a/lib/features/products/product_viewmodel.dart
+++ b/lib/features/products/product_viewmodel.dart
@@ -13,6 +13,7 @@ class ProductViewModel extends ChangeNotifier {
   final Map<String, Product> _likedProductCache = {};
   final Map<String, int> _likeCountOverrides = {};
   final Set<String> _pendingLikeUpdates = {};
+  Future<Result<void>>? _likedProductsHydration;
 
   Product? get product => _product;
 
@@ -43,6 +44,43 @@ class ProductViewModel extends ChangeNotifier {
   // Get dynamic count for a product
   int getLikesCount(Product product) {
     return _likeCountOverrides[product.id] ?? product.likes;
+  }
+
+  Future<Result<void>> hydrateLikedProducts() {
+    final pendingHydration = _likedProductsHydration;
+    if (pendingHydration != null) {
+      return pendingHydration;
+    }
+
+    final hydration = _hydrateLikedProducts();
+    _likedProductsHydration = hydration;
+    return hydration;
+  }
+
+  Future<Result<void>> _hydrateLikedProducts() async {
+    try {
+      _clearCachedLikedState();
+
+      final result = await productRepository.fetchLikedProducts();
+      if (!result.isSuccess) {
+        return Result.failure(result.error ?? 'Unable to restore liked items.');
+      }
+
+      cacheLikedProducts(result.value ?? const []);
+      return Result.success(null);
+    } finally {
+      _likedProductsHydration = null;
+    }
+  }
+
+  void _clearCachedLikedState() {
+    if (_likedProducts.isEmpty && _likedProductCache.isEmpty) {
+      return;
+    }
+
+    _likedProducts.clear();
+    _likedProductCache.clear();
+    notifyListeners();
   }
 
   void setProduct(Product product) {

--- a/test/home_screen_mvp_test.dart
+++ b/test/home_screen_mvp_test.dart
@@ -30,9 +30,21 @@ class _HomeRepositoryStub implements IHomeRepository {
   }
 }
 
-Future<void> _pumpHomeScreen(
+class _ProductRepositoryStub extends ProductRepository {
+  _ProductRepositoryStub(this.likedProducts) : super(const UnexpectedApiService());
+
+  final List<Product> likedProducts;
+
+  @override
+  Future<Result<List<Product>>> fetchLikedProducts() async {
+    return Result.success(likedProducts);
+  }
+}
+
+Future<ProductViewModel> _pumpHomeScreen(
   WidgetTester tester, {
   List<Product> products = const [],
+  List<Product> likedProducts = const [],
   Result<ProductPage>? fetchResult,
   EdgeInsets mediaPadding = EdgeInsets.zero,
 }) async {
@@ -47,6 +59,10 @@ Future<void> _pumpHomeScreen(
           hasMore: false,
         ),
       );
+  final productViewModel = ProductViewModel(
+    productRepository: _ProductRepositoryStub(likedProducts),
+    navigator: navigator,
+  );
 
   await tester.pumpWidget(
     MultiProvider(
@@ -56,13 +72,8 @@ Future<void> _pumpHomeScreen(
         ChangeNotifierProvider<HomeViewModel>(
           create: (_) => HomeViewModel(homeRepository: _HomeRepositoryStub(result)),
         ),
-        ChangeNotifierProvider<ProductViewModel>(
-          create: (_) => ProductViewModel(
-            productRepository: ProductRepository(
-              const UnexpectedApiService(),
-            ),
-            navigator: navigator,
-          ),
+        ChangeNotifierProvider<ProductViewModel>.value(
+          value: productViewModel,
         ),
       ],
       child: MaterialApp(
@@ -75,6 +86,8 @@ Future<void> _pumpHomeScreen(
       ),
     ),
   );
+
+  return productViewModel;
 }
 
 Product _product(int index) {
@@ -149,5 +162,24 @@ void main() {
     expect(find.text(AppStrings.failedToLoadProducts), findsOneWidget);
     expect(find.text('technical failure'), findsOneWidget);
     expect(find.text(AppStrings.noProductsAvailable), findsNothing);
+  });
+
+  testWidgets('HomeScreen restores liked hearts from the API', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final product = _product(1);
+    final productViewModel = await _pumpHomeScreen(
+      tester,
+      products: [product],
+      likedProducts: [product],
+    );
+    await tester.pumpAndSettle();
+
+    expect(productViewModel.isProductLiked(product.id), isTrue);
   });
 }

--- a/test/home_viewmodel_test.dart
+++ b/test/home_viewmodel_test.dart
@@ -1,0 +1,63 @@
+import 'package:cherry_mvp/core/config/app_images.dart';
+import 'package:cherry_mvp/core/models/product.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/home/home_repository.dart';
+import 'package:cherry_mvp/features/home/home_viewmodel.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _HomeRepositoryStub implements IHomeRepository {
+  const _HomeRepositoryStub(this.page);
+
+  final ProductPage page;
+
+  @override
+  Future<Result<ProductPage>> fetchProducts({
+    int limit = 20,
+    String? cursor,
+    String? search,
+  }) async {
+    return Result.success(page);
+  }
+}
+
+void main() {
+  test(
+    'reconciles local counts when Home receives authoritative products',
+    () async {
+      final product = _product(likes: 1);
+      final reconciledProducts = <Product>[];
+      final viewModel = HomeViewModel(
+        homeRepository: _HomeRepositoryStub(
+          ProductPage(
+            products: [product],
+            limit: 20,
+            nextCursor: null,
+            hasMore: false,
+          ),
+        ),
+        onProductsLoaded: reconciledProducts.addAll,
+      );
+
+      await viewModel.fetchProducts();
+
+      expect(reconciledProducts, [product]);
+    },
+  );
+}
+
+Product _product({required int likes}) {
+  return Product(
+    id: 'home-product',
+    name: 'Home item',
+    description: 'A home test product',
+    quality: 'GOOD',
+    productImages: const [AppImages.product1],
+    donation: 7,
+    price: 7,
+    securityFee: 1,
+    likes: likes,
+    number: 1,
+    size: 'M',
+    postageSizeId: 'small',
+  );
+}

--- a/test/liked_items_page_test.dart
+++ b/test/liked_items_page_test.dart
@@ -21,12 +21,14 @@ class _FakeProductRepository extends ProductRepository {
   }) : super(const UnexpectedApiService());
 
   Result<List<Product>> fetchResult;
-  Result<void>? unlikeResult;
+  Result<ProductLikeUpdate>? unlikeResult;
   int fetchCount = 0;
 
   @override
-  Future<Result<void>> likeProduct(Product product) async {
-    return Result.success(null);
+  Future<Result<ProductLikeUpdate>> likeProduct(Product product) async {
+    return Result.success(
+      ProductLikeUpdate(liked: true, likes: product.likes + 1),
+    );
   }
 
   @override
@@ -36,8 +38,9 @@ class _FakeProductRepository extends ProductRepository {
   }
 
   @override
-  Future<Result<void>> unlikeProduct(String productId) async {
-    return unlikeResult ?? Result.success(null);
+  Future<Result<ProductLikeUpdate>> unlikeProduct(String productId) async {
+    return unlikeResult ??
+        Result.success(const ProductLikeUpdate(liked: false, likes: 0));
   }
 }
 

--- a/test/liked_items_view_model_test.dart
+++ b/test/liked_items_view_model_test.dart
@@ -16,12 +16,14 @@ class _FakeProductRepository extends ProductRepository {
   }) : super(const UnexpectedApiService());
 
   Result<List<Product>>? fetchResult;
-  Result<void>? unlikeResult;
+  Result<ProductLikeUpdate>? unlikeResult;
   final unlikedIds = <String>[];
 
   @override
-  Future<Result<void>> likeProduct(Product product) async {
-    return Result.success(null);
+  Future<Result<ProductLikeUpdate>> likeProduct(Product product) async {
+    return Result.success(
+      ProductLikeUpdate(liked: true, likes: product.likes + 1),
+    );
   }
 
   @override
@@ -30,9 +32,10 @@ class _FakeProductRepository extends ProductRepository {
   }
 
   @override
-  Future<Result<void>> unlikeProduct(String productId) async {
+  Future<Result<ProductLikeUpdate>> unlikeProduct(String productId) async {
     unlikedIds.add(productId);
-    return unlikeResult ?? Result.success(null);
+    return unlikeResult ??
+        Result.success(const ProductLikeUpdate(liked: false, likes: 0));
   }
 }
 

--- a/test/product_repository_test.dart
+++ b/test/product_repository_test.dart
@@ -169,7 +169,7 @@ void main() {
       final apiService = _RecordingApiService(
         postValue: const {
           'success': true,
-          'data': {'liked': true},
+          'data': {'liked': true, 'likes': 2},
         },
       );
       final repository = ProductRepository(apiService);
@@ -182,13 +182,15 @@ void main() {
         ApiEndpoints.productLike('liked-product'),
       );
       expect(apiService.lastPostData, {'like': true});
+      expect(result.value!.liked, isTrue);
+      expect(result.value!.likes, 2);
     });
 
     test('unlikes a product through the same API endpoint', () async {
       final apiService = _RecordingApiService(
         postValue: const {
           'success': true,
-          'data': {'liked': false},
+          'data': {'liked': false, 'likes': 0},
         },
       );
       final repository = ProductRepository(apiService);
@@ -201,6 +203,8 @@ void main() {
         ApiEndpoints.productLike('liked-product'),
       );
       expect(apiService.lastPostData, {'like': false});
+      expect(result.value!.liked, isFalse);
+      expect(result.value!.likes, 0);
     });
 
     test('does not call the API for an invalid product ID', () async {
@@ -230,7 +234,23 @@ void main() {
         _RecordingApiService(
           postValue: const {
             'success': true,
-            'data': {'liked': false},
+            'data': {'liked': false, 'likes': 0},
+          },
+        ),
+      );
+
+      final result = await repository.likeProduct(_product());
+
+      expect(result.isSuccess, isFalse);
+      expect(result.error, isNotEmpty);
+    });
+
+    test('rejects a response without an authoritative like count', () async {
+      final repository = ProductRepository(
+        _RecordingApiService(
+          postValue: const {
+            'success': true,
+            'data': {'liked': true},
           },
         ),
       );

--- a/test/product_viewmodel_test.dart
+++ b/test/product_viewmodel_test.dart
@@ -9,10 +9,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'support/unexpected_api_service.dart';
 
 class _LikeUpdateRepository extends ProductRepository {
-  _LikeUpdateRepository({required this.likeUpdate, required this.unlikeUpdate}) : super(const UnexpectedApiService());
+  _LikeUpdateRepository({
+    required this.likeUpdate,
+    required this.unlikeUpdate,
+    this.likedProductsResult,
+  }) : super(const UnexpectedApiService());
 
   final ProductLikeUpdate likeUpdate;
   final ProductLikeUpdate unlikeUpdate;
+  final Result<List<Product>>? likedProductsResult;
+  int fetchLikedProductsCount = 0;
+
+  @override
+  Future<Result<List<Product>>> fetchLikedProducts() async {
+    fetchLikedProductsCount++;
+    return likedProductsResult ?? Result.success(const <Product>[]);
+  }
 
   @override
   Future<Result<ProductLikeUpdate>> likeProduct(Product product) async {
@@ -86,6 +98,63 @@ void main() {
 
     await viewModel.setProductLiked(product, true);
 
+    expect(viewModel.getLikesCount(product), 1);
+  });
+
+  test('shares concurrent liked-state hydration requests', () async {
+    final repository = _LikeUpdateRepository(
+      likeUpdate: const ProductLikeUpdate(liked: true, likes: 1),
+      unlikeUpdate: const ProductLikeUpdate(liked: false, likes: 0),
+    );
+    final viewModel = ProductViewModel(
+      productRepository: repository,
+      navigator: NavigationProvider(),
+    );
+
+    final firstHydration = viewModel.hydrateLikedProducts();
+    final secondHydration = viewModel.hydrateLikedProducts();
+    await Future.wait([firstHydration, secondHydration]);
+
+    expect(identical(firstHydration, secondHydration), isTrue);
+    expect(repository.fetchLikedProductsCount, 1);
+  });
+
+  test('restores liked state from the API after a fresh start', () async {
+    final product = _product(likes: 1);
+    final viewModel = ProductViewModel(
+      productRepository: _LikeUpdateRepository(
+        likeUpdate: const ProductLikeUpdate(liked: true, likes: 1),
+        unlikeUpdate: const ProductLikeUpdate(liked: false, likes: 0),
+        likedProductsResult: Result.success([product]),
+      ),
+      navigator: NavigationProvider(),
+    );
+
+    expect(viewModel.isProductLiked(product.id), isFalse);
+
+    final result = await viewModel.hydrateLikedProducts();
+
+    expect(result.isSuccess, isTrue);
+    expect(viewModel.isProductLiked(product.id), isTrue);
+    expect(viewModel.getLikesCount(product), 1);
+  });
+
+  test('failed hydration clears stale user-specific liked state', () async {
+    final product = _product(likes: 1);
+    final viewModel = ProductViewModel(
+      productRepository: _LikeUpdateRepository(
+        likeUpdate: const ProductLikeUpdate(liked: true, likes: 1),
+        unlikeUpdate: const ProductLikeUpdate(liked: false, likes: 0),
+        likedProductsResult: Result.failure('Load failed'),
+      ),
+      navigator: NavigationProvider(),
+    )..cacheLikedProducts([product]);
+
+    final result = await viewModel.hydrateLikedProducts();
+
+    expect(result.isSuccess, isFalse);
+    expect(viewModel.isProductLiked(product.id), isFalse);
+    expect(viewModel.cachedLikedProducts, isEmpty);
     expect(viewModel.getLikesCount(product), 1);
   });
 }

--- a/test/product_viewmodel_test.dart
+++ b/test/product_viewmodel_test.dart
@@ -1,0 +1,108 @@
+import 'package:cherry_mvp/core/config/app_images.dart';
+import 'package:cherry_mvp/core/models/product.dart';
+import 'package:cherry_mvp/core/router/nav_provider.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/products/product_repository.dart';
+import 'package:cherry_mvp/features/products/product_viewmodel.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/unexpected_api_service.dart';
+
+class _LikeUpdateRepository extends ProductRepository {
+  _LikeUpdateRepository({required this.likeUpdate, required this.unlikeUpdate}) : super(const UnexpectedApiService());
+
+  final ProductLikeUpdate likeUpdate;
+  final ProductLikeUpdate unlikeUpdate;
+
+  @override
+  Future<Result<ProductLikeUpdate>> likeProduct(Product product) async {
+    return Result.success(likeUpdate);
+  }
+
+  @override
+  Future<Result<ProductLikeUpdate>> unlikeProduct(String productId) async {
+    return Result.success(unlikeUpdate);
+  }
+}
+
+void main() {
+  test(
+    'keeps API like counts consistent across like, refresh and unlike',
+    () async {
+      final repository = _LikeUpdateRepository(
+        likeUpdate: const ProductLikeUpdate(liked: true, likes: 1),
+        unlikeUpdate: const ProductLikeUpdate(liked: false, likes: 0),
+      );
+      final viewModel = ProductViewModel(
+        productRepository: repository,
+        navigator: NavigationProvider(),
+      );
+      final originalHomeProduct = _product(likes: 0);
+
+      expect(viewModel.getLikesCount(originalHomeProduct), 0);
+
+      final liked = await viewModel.setProductLiked(originalHomeProduct, true);
+
+      expect(liked.value, isTrue);
+      expect(viewModel.isProductLiked(originalHomeProduct.id), isTrue);
+      expect(viewModel.getLikesCount(originalHomeProduct), 1);
+
+      final likedApiProduct = _product(likes: 2);
+      viewModel.cacheLikedProducts([likedApiProduct]);
+
+      expect(viewModel.getLikesCount(likedApiProduct), 2);
+      expect(viewModel.getLikesCount(originalHomeProduct), 2);
+
+      final refreshedHomeProduct = _product(likes: 1);
+      viewModel.reconcileProductCounts([refreshedHomeProduct]);
+
+      expect(viewModel.getLikesCount(refreshedHomeProduct), 1);
+
+      final unliked = await viewModel.setProductLiked(
+        refreshedHomeProduct,
+        false,
+      );
+
+      expect(unliked.value, isFalse);
+      expect(viewModel.isProductLiked(refreshedHomeProduct.id), isFalse);
+      expect(viewModel.getLikesCount(refreshedHomeProduct), 0);
+
+      final unlikedApiProduct = _product(likes: 0);
+      viewModel.reconcileProductCounts([unlikedApiProduct]);
+
+      expect(viewModel.getLikesCount(unlikedApiProduct), 0);
+    },
+  );
+
+  test('uses an idempotent API count without adding another like', () async {
+    final product = _product(likes: 1);
+    final viewModel = ProductViewModel(
+      productRepository: _LikeUpdateRepository(
+        likeUpdate: const ProductLikeUpdate(liked: true, likes: 1),
+        unlikeUpdate: const ProductLikeUpdate(liked: false, likes: 0),
+      ),
+      navigator: NavigationProvider(),
+    );
+
+    await viewModel.setProductLiked(product, true);
+
+    expect(viewModel.getLikesCount(product), 1);
+  });
+}
+
+Product _product({required int likes}) {
+  return Product(
+    id: 'liked-product',
+    name: 'Liked item',
+    description: 'A liked test product',
+    quality: 'GOOD',
+    productImages: const [AppImages.product1],
+    donation: 7,
+    price: 7,
+    securityFee: 1,
+    likes: likes,
+    number: 1,
+    size: 'M',
+    postageSizeId: 'small',
+  );
+}


### PR DESCRIPTION
## Purpose

Addresses #468 and the related restart-state bug in the liked-products flow.

Two separate client-side problems caused the visible inconsistencies:

- The backend `likes` total already included the signed-in user's like, but the app added another local `+1`.
- The red heart state existed only in memory. After an app restart, Home products did not include a per-user `liked` field, so the count remained correct while the heart reverted to unliked.

## Changes

Type: frontend state logic, existing API integration, and tests. No backend, Firebase, Firestore, configuration, or dependency changes.

- Treat `data.liked` and `data.likes` from `POST /api/products/{id}/like` as the authoritative mutation result.
- Remove the extra client-side count increment.
- Share API counts across Home, Product, and Liked Items, and reconcile them when newer API product data arrives.
- Restore the signed-in user's liked product IDs from `GET /api/products/my-liked-items` when the authenticated Home dashboard starts.
- Share concurrent hydration calls so only one liked-items request is active at a time.
- Keep Home usable if hydration fails, while clearing stale user-specific heart state rather than showing data from a previous session.
- Add regression tests for count consistency, idempotent API responses, startup hydration, concurrent hydration, and non-fatal hydration failure.

## Review focus

- Confirm the deployed like endpoint consistently returns both `data.liked` and a non-negative `data.likes` value. The client now rejects incomplete successful responses instead of inventing state.
- Check that startup hydration occurs only after the existing authentication and username gates have completed.
- Confirm the current `GET /api/products/my-liked-items` request limit of 50 is acceptable for the MVP. Pagination is not added in this PR, so users with more than 50 liked products may not have every Home heart restored.
- Hydration failure deliberately does not block Home. Hearts remain unliked until a later successful hydration or user action.

## Testing

Passed locally:

- `flutter test test/product_repository_test.dart test/product_viewmodel_test.dart test/home_viewmodel_test.dart test/home_screen_mvp_test.dart test/liked_items_view_model_test.dart`
- `flutter test test/liked_items_page_test.dart --name '^(?!tapping a liked product opens the existing product page$).*'`
- Targeted `flutter analyze` for the changed production and test files
- `dart format --output=none --set-exit-if-changed` for the changed files
- `git diff --check`

Full-suite result after this commit: 64 tests passed and 6 failed. The failures are existing repository test/configuration problems involving missing constructor dependencies, a stale model/date expectation, a missing checkout provider in one navigation test, and one concurrent compiler exit. The focused versions of the affected liked-items tests pass.

Live signed-in restart validation is still required after installing this exact branch build. The intended check is: like a product, confirm the heart is red and count is 1, restart the app, then confirm the same heart remains red and the count remains 1.