### PR TITLE
Bugfix: Resolve baseline Flutter test failures

### DIFF
--- a/test/donation_model_test.dart
+++ b/test/donation_model_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:cherry_mvp/features/donation/models/donation_model.dart';
 
 void main() {
-  test('DonationRequest sends postage_size as the backend enum value', () {
+  test('DonationRequest serialises the backend postage size ID', () {
     final request = DonationRequest(
       name: 'Jumper',
       description: 'Warm wool jumper',
@@ -15,6 +15,6 @@ void main() {
       price: 12,
     );
 
-    expect(request.toJson()['postage_size'], 'medium');
+    expect(request.toJson()['postageSize'], 'HnGf34ED');
   });
 }

--- a/test/liked_items_page_test.dart
+++ b/test/liked_items_page_test.dart
@@ -3,6 +3,9 @@ import 'package:cherry_mvp/core/config/app_strings.dart';
 import 'package:cherry_mvp/core/models/product.dart';
 import 'package:cherry_mvp/core/router/router.dart';
 import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/checkout/checkout_repository.dart';
+import 'package:cherry_mvp/features/checkout/checkout_view_model.dart';
+import 'package:cherry_mvp/features/donation/donation_repository.dart';
 import 'package:cherry_mvp/features/liked_items/liked_items_page.dart';
 import 'package:cherry_mvp/features/products/product_card.dart';
 import 'package:cherry_mvp/features/products/product_page.dart';
@@ -13,6 +16,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
 import 'support/unexpected_api_service.dart';
+
+class _CheckoutRepositoryStub implements ICheckoutRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _DonationRepositoryStub implements IDonationRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 class _FakeProductRepository extends ProductRepository {
   _FakeProductRepository({
@@ -39,8 +52,7 @@ class _FakeProductRepository extends ProductRepository {
 
   @override
   Future<Result<ProductLikeUpdate>> unlikeProduct(String productId) async {
-    return unlikeResult ??
-        Result.success(const ProductLikeUpdate(liked: false, likes: 0));
+    return unlikeResult ?? Result.success(const ProductLikeUpdate(liked: false, likes: 0));
   }
 }
 
@@ -70,6 +82,11 @@ Future<void> _pumpLikedItemsPage(
     productRepository: repository,
     navigator: navigator,
   );
+  final checkoutViewModel = CheckoutViewModel(
+    donationRepository: _DonationRepositoryStub(),
+    checkoutRepository: _CheckoutRepositoryStub(),
+    navigator: navigator,
+  );
 
   await tester.pumpWidget(
     MultiProvider(
@@ -77,6 +94,9 @@ Future<void> _pumpLikedItemsPage(
         Provider<NavigationProvider>.value(value: navigator),
         Provider<ProductRepository>.value(value: repository),
         ChangeNotifierProvider<ProductViewModel>.value(value: productViewModel),
+        ChangeNotifierProvider<CheckoutViewModel>.value(
+          value: checkoutViewModel,
+        ),
       ],
       child: MaterialApp(
         navigatorKey: navigator.navigatorKey,

--- a/test/mvp_profile_stats_test.dart
+++ b/test/mvp_profile_stats_test.dart
@@ -13,6 +13,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 
+import 'support/unexpected_api_service.dart';
+
 class _MockLoginRepository extends Mock implements LoginRepository {}
 
 class _MockNavigationProvider extends Mock implements NavigationProvider {}
@@ -27,6 +29,7 @@ AuthViewModel _authViewModel() {
     navigator: _MockNavigationProvider(),
     firebaseAuth: _MockFirebaseAuth(),
     firestore: _MockFirebaseFirestore(),
+    apiService: const UnexpectedApiService(),
   );
 }
 

--- a/test/product_self_purchase_test.dart
+++ b/test/product_self_purchase_test.dart
@@ -13,6 +13,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'support/unexpected_api_service.dart';
+
 class _CheckoutRepositoryStub implements ICheckoutRepository {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -35,7 +37,7 @@ void main() {
 
     final navigator = NavigationProvider();
     final productViewModel = ProductViewModel(
-      productRepository: ProductRepository(),
+      productRepository: ProductRepository(const UnexpectedApiService()),
       navigator: navigator,
     )..setProduct(_product);
     final checkoutViewModel = CheckoutViewModel(

--- a/test/settings_legal_information_test.dart
+++ b/test/settings_legal_information_test.dart
@@ -47,7 +47,7 @@ void main() {
     }
 
     expect(find.text(AppStrings.privacyPolicyText), findsWidgets);
-    expect(find.text('Date last updated: 2024-13-11'), findsOneWidget);
+    expect(find.text('Date last updated: 05.07.2026'), findsOneWidget);
     expect(find.text('1. General'), findsOneWidget);
 
     await tester.pageBack();


### PR DESCRIPTION
### Fixes https://github.com/Cherry-CIC/MVP/issues/469 as raised by @VitaliiKoliuka 

**As well as two other known failures outside of this issue.**
The two additional baseline failures were:

1. `donation_model_test.dart`
The test expected the old donation format:
- Field: `postage_size`
- Value: `medium`
The app now correctly sends:
- Field: `postageSize`
- Value: the selected backend postage-size ID
The test was updated to reflect the current API contract. Production code was not changed.
-----
2. `settings_legal_information_test.dart`
The test expected this invalid date:
- `2024-13-11`
The bundled Privacy Policy actually states:
- `05.07.2026`
The incorrect test expectation was corrected. The legal document itself was not changed.

These were the only two additional known failures. After correcting them, the entire suite passed: **71 tests, zero failures**.
----
## What changed

- Supply the required `ApiService` when profile tests create `AuthViewModel`.
- Supply the required `ApiService` when the self-purchase test creates `ProductRepository`.
- Provide `CheckoutViewModel` and isolated repository stubs when the Liked Items navigation test opens `ProductPage`.
- Update the donation model test to verify the current `postageSize` backend ID contract.
- Correct the legal information test to match the bundled Privacy Policy metadata.

## Why

Five baseline failures remained on `main`.

Three test setups had not kept pace with required Flutter dependencies. The other two expectations were stale:

- the donation test still asserted the superseded `postage_size` enum contract instead of the current `postageSize` backend ID;
- the legal information test expected an invalid date that never matched the bundled Privacy Policy.

The tests use `UnexpectedApiService` and local repository stubs, so they cannot silently call live APIs or external services.

## Impact

Test-only change. There are no production, backend, Firebase, Firestore, Stripe, Swagger, Android or iOS configuration changes.

## Validation

Passed:

- `flutter analyze`
- `flutter test` (71 tests)
- all five issue-specific test files together (12 tests)
- focused rerun of the two corrected baseline tests
- `git diff --check`

I tested it after making the changes...

Results:

- `flutter analyze`: **passed with no issues**
- All five issue-specific test files: **12 tests passed**
- Complete `flutter test` suite: **71 tests passed, zero failures**
- Formatting and whitespace checks: **passed**

I also reproduced the two remaining failures before fixing them, then reran them afterwards and confirmed they passed.