### PR TITLE
Clarify checkout payment confirmation wording

### DIFF
--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -251,8 +251,8 @@ class AppStrings {
   static const checkoutOrderPlaced = 'Order Placed 🎉';
   static const checkoutThankYou = 'Thank you';
   static const checkoutEscrowInfo =
-      'Your payment will be held in escrow until the seller sends the item and '
-      'you confirm it, after which it will be sent to the charity!';
+      "Your payment is sent to the charity as soon as you confirm you're happy "
+      'with the order!';
   static const checkoutTrackOrders = 'Track Orders';
   static const checkoutImpactSummary = 'Impact Summary';
   static const checkoutReview = 'Review';


### PR DESCRIPTION
## Summary

- UI-only change in `lib/core/config/app_strings.dart`.
- Rewords checkout escrow information to state that payment is sent to the charity after the buyer confirms they are happy with the order.
- Removes the previous reference to seller dispatch and escrow holding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated checkout escrow information to clarify that payment is sent to the charity after the buyer confirms satisfaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->