### PR TITLE
fix: install ripgrep for safe logging workflow

### DIFF
--- a/.github/workflows/safe-logging.yml
+++ b/.github/workflows/safe-logging.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Check logging policy
         run: bash tool/check_safe_logging.sh
 


### PR DESCRIPTION
## What changed

- Added a step to install `ripgrep` before running the safe logging policy check.

## Why

The safe logging workflow was failing with:

`rg: command not found`

because `tool/check_safe_logging.sh` depends on ripgrep.

Closes #476.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `ripgrep` installation to the automated safe logging policy check.
  * Improved reliability of logging compliance validation in the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->