### PR TITLE
Prefetch charities and categories before opening Donate page

### DIFF
--- a/lib/features/categories/category_view_model.dart
+++ b/lib/features/categories/category_view_model.dart
@@ -49,7 +49,11 @@ class CategoryViewModel extends ChangeNotifier {
     });
   }
 
-  Future<void> fetchCategories() async {
+  Future<void> fetchCategories({bool forceRefresh = false}) async {
+    if (!forceRefresh && _categories.isNotEmpty && _status.type == StatusType.success) {
+      return;
+    }
+
     _status = Status.loading;
     notifyListeners();
 

--- a/lib/features/charity_page/charity_page.dart
+++ b/lib/features/charity_page/charity_page.dart
@@ -119,7 +119,7 @@ class CharityPageState extends State<CharityPage> {
             Text('${AppStrings.charityError}: ${status.message}'),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () => viewModel.fetchCharities(),
+              onPressed: () => viewModel.fetchCharities(forceRefresh: true),
               child: Text(AppStrings.retry),
             ),
           ],

--- a/lib/features/charity_page/charity_viewmodel.dart
+++ b/lib/features/charity_page/charity_viewmodel.dart
@@ -19,7 +19,11 @@ class CharityViewModel extends ChangeNotifier {
   Status get status => _status;
   List<Charity> get charities => _charities;
 
-  Future<void> fetchCharities() async {
+  Future<void> fetchCharities({bool forceRefresh = false}) async {
+    if (!forceRefresh && _charities.isNotEmpty && _status.type == StatusType.success) {
+      return;
+    }
+
     _status = Status.loading;
     notifyListeners();
 

--- a/lib/features/donation/widgets/donation_form.dart
+++ b/lib/features/donation/widgets/donation_form.dart
@@ -188,17 +188,10 @@ class DonationFormState extends State<DonationForm> {
                   final categories = categoryViewModel.categories;
 
                   if (status.type == StatusType.loading) {
-                    return const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 16.0),
-                      child: Center(
-                        child: Column(
-                          children: [
-                            CircularProgressIndicator(),
-                            SizedBox(height: 8),
-                            Text('Loading categories...'),
-                          ],
-                        ),
-                      ),
+                    return _SelectionField(
+                      label: AppStrings.charityText,
+                      value: null,
+                      onTap: null,
                     );
                   } else if (status.type == StatusType.failure) {
                     return Padding(
@@ -213,7 +206,7 @@ class DonationFormState extends State<DonationForm> {
                           ),
                           const SizedBox(height: 8),
                           ElevatedButton(
-                            onPressed: () => categoryViewModel.fetchCategories(),
+                            onPressed: () => categoryViewModel.fetchCategories(forceRefresh: true),
                             child: const Text(AppStrings.retry),
                           ),
                         ],
@@ -250,17 +243,10 @@ class DonationFormState extends State<DonationForm> {
                   final charities = charityViewModel.charities;
 
                   if (status.type == StatusType.loading) {
-                    return const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 16.0),
-                      child: Center(
-                        child: Column(
-                          children: [
-                            CircularProgressIndicator(),
-                            SizedBox(height: 8),
-                            Text(AppStrings.loadCharities),
-                          ],
-                        ),
-                      ),
+                    return _SelectionField(
+                      label: categoryHintText,
+                      value: null,
+                      onTap: null,
                     );
                   } else if (status.type == StatusType.failure) {
                     return Padding(
@@ -275,7 +261,7 @@ class DonationFormState extends State<DonationForm> {
                           ),
                           const SizedBox(height: 8),
                           ElevatedButton(
-                            onPressed: () => charityViewModel.fetchCharities(),
+                            onPressed: () => charityViewModel.fetchCharities(forceRefresh: true),
                             child: const Text(AppStrings.retry),
                           ),
                         ],
@@ -502,7 +488,7 @@ class _SelectionField extends StatelessWidget {
 
   final String label;
   final String? value;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -8,6 +8,8 @@ import 'package:cherry_mvp/features/messages/message_page.dart';
 import 'package:cherry_mvp/features/orders/orders_page.dart';
 import 'package:cherry_mvp/features/profile/profile_page.dart';
 import 'package:cherry_mvp/features/profile/profile_listings_view_model.dart';
+import 'package:cherry_mvp/features/charity_page/charity_viewmodel.dart';
+import 'package:cherry_mvp/features/categories/category_view_model.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -25,8 +27,7 @@ class _HomePageState extends State<HomePage> {
   static const int _inboxNavIndex = 1;
   static const int _giveNavIndex = FeatureFlags.showInbox ? 2 : 1;
   static const int _searchNavIndex = _giveNavIndex + 1;
-  static const int _profileNavIndex =
-      _giveNavIndex + (FeatureFlags.showSearchNavigation ? 2 : 1);
+  static const int _profileNavIndex = _giveNavIndex + (FeatureFlags.showSearchNavigation ? 2 : 1);
 
   int _selectedIndex = 0;
   bool _showOrders = false;
@@ -58,6 +59,11 @@ class _HomePageState extends State<HomePage> {
     }
 
     if (index == _giveNavIndex) {
+      // Start loading charities and categories before the donation form is
+      // built, so the dropdowns are populated without showing loading states.
+      context.read<CharityViewModel>().fetchCharities();
+      context.read<CategoryViewModel>().fetchCategories();
+
       showDialog(
         context: context,
         builder: (context) => Dialog.fullscreen(child: DonationPage()),

--- a/lib/features/search/widgets/category_page/category_page.dart
+++ b/lib/features/search/widgets/category_page/category_page.dart
@@ -35,7 +35,7 @@ class CategoryPageState extends State<CategoryPage> {
         listen: false,
       );
       if (categoryViewModel.categories.isEmpty) {
-        categoryViewModel.fetchCategories();
+        categoryViewModel.fetchCategories(forceRefresh: true);
       }
     }
   }


### PR DESCRIPTION
Fetches charities and categories before the Donate page renders, so the form appears without loading spinners.

### Changes
- `CharityViewModel` / `CategoryViewModel`: skip the fetch when the data is already loaded. Retry buttons pass `forceRefresh: true`.
- `home_page.dart`: both fetches start when the Give tab is tapped, before the donation dialog opens.
- `donation_form.dart`: the loading branches now render the normal selection field with placeholder text instead of a spinner, so the form appears complete and doesn't shift when data arrives.

Because the lists are cached, the Donate page is instant on every visit after the first. This also stops the charity and category pages refetching the same data.

### Testing
Verified on the iOS simulator. The charity field populates with no spinner.

Note: "Error loading categories" appears on the Donate page, but I confirmed it happens on `main` too, so it looks like a separate problem with the categories endpoint rather than anything in this change. The error branch renders as expected.

`AppStrings.loadCharities` is now unused. Happy to remove it if you'd like, left it to keep the diff focused.

Closes #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Category and charity data now loads before opening the donation form.
  * Selectors remain visible but disabled while category or charity data is loading.
  * Retry actions now request the latest data from the server.

* **Bug Fixes**
  * Prevented unnecessary repeated loading when category or charity data is already available.
  * Improved initial category loading when no categories are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->