### PR TITLE
Added 'edit profile' page

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -29,3 +29,9 @@ linter:
 formatter:
   page_width: 120
   trailing_commas: preserve
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**

--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -68,6 +68,17 @@ class AppStrings {
   static const profileListingsEmpty = 'You have not listed anything yet.';
   static const profileListingsCreate = 'List an item';
   static const profileListingsLoadMore = 'Load more listings';
+
+  // Edit profile
+  static const editProfileTitle = 'Edit profile';
+  static const editProfileFirstNameLabel = 'First name';
+  static const editProfileUsernameLabel = 'Username';
+  static const editProfilePhoneLabel = 'Phone number';
+  static const editProfileEmailHelper = 'Email cannot be changed here';
+  static const editProfileSave = 'Save changes';
+  static const editProfileSaveSuccess = 'Profile updated';
+  static const editProfileSaveFailed =
+      'Could not update profile. Please try again.';
   static const profileListingsLoadMoreFailed = 'We could not load more listings.';
   static const profileListingUntitled = 'Untitled listing';
   static const profileListingPriceUnavailable = 'Price unavailable';

--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -79,6 +79,8 @@ class AppStrings {
   static const editProfileSaveSuccess = 'Profile updated';
   static const editProfileSaveFailed =
       'Could not update profile. Please try again.';
+  static const editProfileUsernameNotSaved =
+      'Your details were saved, but the username could not be updated. Please try the username again.';
   static const profileListingsLoadMoreFailed = 'We could not load more listings.';
   static const profileListingUntitled = 'Untitled listing';
   static const profileListingPriceUnavailable = 'Price unavailable';

--- a/lib/core/router/nav_routes.dart
+++ b/lib/core/router/nav_routes.dart
@@ -11,6 +11,7 @@ import 'package:cherry_mvp/features/liked_items/liked_items_page.dart';
 import 'package:cherry_mvp/features/login/login_page.dart';
 import 'package:cherry_mvp/features/forgot_password/forgot_password_page.dart';
 import 'package:cherry_mvp/features/products/product_page.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_page.dart';
 import 'package:cherry_mvp/features/register/register_page.dart';
 import 'package:cherry_mvp/features/search/widgets/category_page/category_page.dart';
 import 'package:cherry_mvp/features/settings/faq_page.dart';
@@ -44,6 +45,7 @@ class AppRoutes {
   static const String postageSize = '/postageSize';
   static const String pickupPointSelector = '/pickupPointSelector';
   static const String likedItems = '/liked-items';
+  static const String editProfile = '/editProfile';
 
   static Route<dynamic> generateRoute(RouteSettings settings) {
     switch (settings.name) {
@@ -63,6 +65,8 @@ class AppRoutes {
         return MaterialPageRoute(builder: (_) => DiscoverPage());
       case likedItems:
         return MaterialPageRoute(builder: (_) => const LikedItemsPage());
+      case editProfile:
+        return MaterialPageRoute(builder: (_) => const EditProfilePage());
       case settingspage:
         return MaterialPageRoute(builder: (_) => SettingsPage());
       case donations:

--- a/lib/core/utils/dependency.dart
+++ b/lib/core/utils/dependency.dart
@@ -30,6 +30,8 @@ import 'package:cherry_mvp/features/orders/orders_repository.dart';
 import 'package:cherry_mvp/features/orders/orders_view_model.dart';
 import 'package:cherry_mvp/features/products/product_repository.dart';
 import 'package:cherry_mvp/features/products/product_viewmodel.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_repository.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_view_model.dart';
 import 'package:cherry_mvp/features/profile/profile_listings_repository.dart';
 import 'package:cherry_mvp/features/profile/profile_listings_view_model.dart';
 import 'package:cherry_mvp/features/register/register_repository.dart';
@@ -108,8 +110,7 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
     ),
     Provider<DiscoverRepository>(create: (context) => DiscoverRepository()),
     Provider<ProductRepository>(
-      create: (context) =>
-          ProductRepository(Provider.of<ApiService>(context, listen: false)),
+      create: (context) => ProductRepository(Provider.of<ApiService>(context, listen: false)),
     ),
     Provider<IDonationRepository>(
       create: (context) {
@@ -142,11 +143,15 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
       },
     ),
     Provider<IOrdersRepository>(
-      create: (context) =>
-          OrdersRepository(Provider.of<ApiService>(context, listen: false)),
+      create: (context) => OrdersRepository(Provider.of<ApiService>(context, listen: false)),
     ),
     Provider<IProfileListingsRepository>(
       create: (context) => ProfileListingsRepository(
+        Provider.of<ApiService>(context, listen: false),
+      ),
+    ),
+    Provider<IEditProfileRepository>(
+      create: (context) => EditProfileRepository(
         Provider.of<ApiService>(context, listen: false),
       ),
     ),
@@ -192,8 +197,7 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
           listen: false,
         ),
         navigator: Provider.of<NavigationProvider>(context, listen: false),
-        currentUserIdProvider: () =>
-            Provider.of<FirebaseAuth>(context, listen: false).currentUser?.uid,
+        currentUserIdProvider: () => Provider.of<FirebaseAuth>(context, listen: false).currentUser?.uid,
       ),
     ),
     ChangeNotifierProvider<HomeViewModel>(
@@ -252,8 +256,7 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
           context,
           listen: false,
         ),
-        currentUserIdProvider: () =>
-            Provider.of<FirebaseAuth>(context, listen: false).currentUser?.uid,
+        currentUserIdProvider: () => Provider.of<FirebaseAuth>(context, listen: false).currentUser?.uid,
       ),
     ),
     ChangeNotifierProvider<CharityViewModel>(
@@ -276,6 +279,11 @@ List<SingleChildWidget> buildProviders(SharedPreferences prefs) {
           context,
           listen: false,
         ),
+      ),
+    ),
+    ChangeNotifierProvider<EditProfileViewModel>(
+      create: (context) => EditProfileViewModel(
+        repository: Provider.of<IEditProfileRepository>(context, listen: false),
       ),
     ),
     // Logout provider

--- a/lib/features/profile/edit_profile_page.dart
+++ b/lib/features/profile/edit_profile_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cherry_mvp/core/config/config.dart';
+import 'package:cherry_mvp/core/models/user.dart';
 import 'package:cherry_mvp/core/router/router.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
 import 'package:cherry_mvp/features/auth/auth_view_model.dart';
@@ -14,24 +15,65 @@ class EditProfilePage extends StatefulWidget {
 }
 
 class _EditProfilePageState extends State<EditProfilePage> {
+  @override
+  void initState() {
+    super.initState();
+
+    final auth = context.read<AuthViewModel>();
+    if (auth.userCredentials == null && !auth.isLoadingUser) {
+      Future.microtask(() {
+        if (mounted) auth.loadCurrentUser();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final credentials = context.watch<AuthViewModel>().userCredentials;
+
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text(AppStrings.editProfileTitle),
+      ),
+      body: SafeArea(
+        child: credentials == null
+            ? const Center(child: CircularProgressIndicator())
+            : _EditProfileForm(credentials: credentials),
+      ),
+    );
+  }
+}
+
+/// Only show once the [credentials] have loaded
+class _EditProfileForm extends StatefulWidget {
+  const _EditProfileForm({required this.credentials});
+
+  final UserCredentials credentials;
+
+  @override
+  State<_EditProfileForm> createState() => _EditProfileFormState();
+}
+
+class _EditProfileFormState extends State<_EditProfileForm> {
   final _formKey = GlobalKey<FormState>();
 
   late final TextEditingController _firstNameController;
   late final TextEditingController _usernameController;
   late final TextEditingController _phoneController;
 
-  String _initialFirstName = '';
-  String _initialUsername = '';
-  String _initialPhone = '';
+  late final String _initialFirstName;
+  late final String _initialUsername;
+  late final String _initialPhone;
 
   @override
   void initState() {
     super.initState();
-    final credentials = context.read<AuthViewModel>().userCredentials;
+    final credentials = widget.credentials;
 
-    _initialFirstName = credentials?.firstname?.trim() ?? '';
-    _initialUsername = credentials?.username?.trim() ?? '';
-    _initialPhone = credentials?.phoneNumber?.trim() ?? '';
+    _initialFirstName = credentials.firstname?.trim() ?? '';
+    _initialUsername = credentials.username?.trim() ?? '';
+    _initialPhone = credentials.phoneNumber?.trim() ?? '';
 
     _firstNameController = TextEditingController(text: _initialFirstName);
     _usernameController = TextEditingController(text: _initialUsername);
@@ -82,7 +124,8 @@ class _EditProfilePageState extends State<EditProfilePage> {
       return;
     }
 
-    final result = await context.read<EditProfileViewModel>().saveProfile(
+    final editProfile = context.read<EditProfileViewModel>();
+    final result = await editProfile.saveProfile(
       uid: uid,
       firstName: firstName,
       username: username,
@@ -92,6 +135,13 @@ class _EditProfilePageState extends State<EditProfilePage> {
     if (!mounted) return;
 
     if (!result.isSuccess) {
+      // Some of the writes may still have landed, so pull the server state back
+      // down before showing the error instead of leaving stale values on screen.
+      if (editProfile.isPartialSave) {
+        await auth.loadCurrentUser();
+        if (!mounted) return;
+      }
+
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(result.error ?? AppStrings.editProfileSaveFailed)),
       );
@@ -109,96 +159,84 @@ class _EditProfilePageState extends State<EditProfilePage> {
 
   @override
   Widget build(BuildContext context) {
-    final email = context.select<AuthViewModel, String?>(
-      (auth) => auth.userCredentials?.email,
-    );
-    final photoUrl = context.select<AuthViewModel, String?>(
-      (auth) => auth.userCredentials?.photoUrl,
-    );
+    final photoUrl = widget.credentials.photoUrl;
     final isSaving = context.watch<EditProfileViewModel>().isSaving;
 
-    return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: const Text(AppStrings.editProfileTitle),
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Form(
-            key: _formKey,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Center(
-                  child: CircleAvatar(
-                    radius: 40,
-                    backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
-                    backgroundImage: (photoUrl != null && photoUrl.isNotEmpty)
-                        ? NetworkImage(photoUrl)
-                        : AssetImage(AppImages.profileProfileIcon) as ImageProvider,
-                  ),
-                ),
-                const SizedBox(height: 24),
-                TextFormField(
-                  controller: _firstNameController,
-                  enabled: !isSaving,
-                  textCapitalization: TextCapitalization.words,
-                  validator: _validateOptionalFirstName,
-                  decoration: const InputDecoration(
-                    labelText: AppStrings.editProfileFirstNameLabel,
-                    prefixIcon: Icon(Icons.badge_outlined),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: _usernameController,
-                  enabled: !isSaving,
-                  validator: (value) {
-                    if ((value ?? '').trim().isEmpty) return null;
-                    return validateUsername(value);
-                  },
-                  decoration: const InputDecoration(
-                    labelText: AppStrings.editProfileUsernameLabel,
-                    prefixIcon: Icon(Icons.person_outline),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: _phoneController,
-                  enabled: !isSaving,
-                  keyboardType: TextInputType.phone,
-                  validator: _validateOptionalPhone,
-                  decoration: const InputDecoration(
-                    labelText: AppStrings.editProfilePhoneLabel,
-                    prefixIcon: Icon(Icons.phone_outlined),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  enabled: false,
-                  initialValue: email ?? '',
-                  decoration: const InputDecoration(
-                    labelText: AppStrings.email,
-                    prefixIcon: Icon(Icons.email_outlined),
-                    helperText: AppStrings.editProfileEmailHelper,
-                  ),
-                ),
-                const SizedBox(height: 32),
-                // TODO: Change to BottomCTA when merged
-                SizedBox(
-                  height: 56,
-                  child: isSaving
-                      ? const Center(child: CircularProgressIndicator())
-                      : FilledButton(
-                          onPressed: _save,
-                          child: const Text(AppStrings.editProfileSave),
-                        ),
-                ),
-                SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
-              ],
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(
+              child: CircleAvatar(
+                radius: 40,
+                backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+                backgroundImage: (photoUrl != null && photoUrl.isNotEmpty)
+                    ? NetworkImage(photoUrl)
+                    : AssetImage(AppImages.profileProfileIcon) as ImageProvider,
+              ),
             ),
-          ),
+            const SizedBox(height: 24),
+            TextFormField(
+              controller: _firstNameController,
+              enabled: !isSaving,
+              textCapitalization: TextCapitalization.words,
+              validator: _validateOptionalFirstName,
+              decoration: const InputDecoration(
+                labelText: AppStrings.editProfileFirstNameLabel,
+                prefixIcon: Icon(Icons.badge_outlined),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _usernameController,
+              enabled: !isSaving,
+              validator: (value) {
+                if ((value ?? '').trim().isEmpty) return null;
+                return validateUsername(value);
+              },
+              decoration: const InputDecoration(
+                labelText: AppStrings.editProfileUsernameLabel,
+                prefixIcon: Icon(Icons.person_outline),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _phoneController,
+              enabled: !isSaving,
+              keyboardType: TextInputType.phone,
+              validator: _validateOptionalPhone,
+              decoration: const InputDecoration(
+                labelText: AppStrings.editProfilePhoneLabel,
+                prefixIcon: Icon(Icons.phone_outlined),
+              ),
+            ),
+            const SizedBox(height: 16),
+            // Read-only: the backend's update endpoint does not accept email.
+            TextFormField(
+              enabled: false,
+              initialValue: widget.credentials.email ?? '',
+              decoration: const InputDecoration(
+                labelText: AppStrings.email,
+                prefixIcon: Icon(Icons.email_outlined),
+                helperText: AppStrings.editProfileEmailHelper,
+              ),
+            ),
+            const SizedBox(height: 32),
+            // TODO: Change to BottomCTA when merged
+            SizedBox(
+              height: 56,
+              child: isSaving
+                  ? const Center(child: CircularProgressIndicator())
+                  : FilledButton(
+                      onPressed: _save,
+                      child: const Text(AppStrings.editProfileSave),
+                    ),
+            ),
+            SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
+          ],
         ),
       ),
     );

--- a/lib/features/profile/edit_profile_page.dart
+++ b/lib/features/profile/edit_profile_page.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:cherry_mvp/core/config/config.dart';
+import 'package:cherry_mvp/core/router/router.dart';
+import 'package:cherry_mvp/core/utils/utils.dart';
+import 'package:cherry_mvp/features/auth/auth_view_model.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_view_model.dart';
+
+class EditProfilePage extends StatefulWidget {
+  const EditProfilePage({super.key});
+
+  @override
+  State<EditProfilePage> createState() => _EditProfilePageState();
+}
+
+class _EditProfilePageState extends State<EditProfilePage> {
+  final _formKey = GlobalKey<FormState>();
+
+  late final TextEditingController _firstNameController;
+  late final TextEditingController _usernameController;
+  late final TextEditingController _phoneController;
+
+  String _initialFirstName = '';
+  String _initialUsername = '';
+  String _initialPhone = '';
+
+  @override
+  void initState() {
+    super.initState();
+    final credentials = context.read<AuthViewModel>().userCredentials;
+
+    _initialFirstName = credentials?.firstname?.trim() ?? '';
+    _initialUsername = credentials?.username?.trim() ?? '';
+    _initialPhone = credentials?.phoneNumber?.trim() ?? '';
+
+    _firstNameController = TextEditingController(text: _initialFirstName);
+    _usernameController = TextEditingController(text: _initialUsername);
+    _phoneController = TextEditingController(text: _initialPhone);
+  }
+
+  @override
+  void dispose() {
+    _firstNameController.dispose();
+    _usernameController.dispose();
+    _phoneController.dispose();
+    super.dispose();
+  }
+
+  String? _validateOptionalFirstName(String? value) {
+    if ((value ?? '').trim().isEmpty) return null;
+    return validateFirstName(value);
+  }
+
+  String? _validateOptionalPhone(String? value) {
+    if ((value ?? '').trim().isEmpty) return null;
+    return validatePhoneNumber(value);
+  }
+
+  /// Returns the trimmed value when it is non-empty and differs from the
+  /// initial value, otherwise null (meaning "do not update this field").
+  String? _changedValue(String current, String initial) {
+    final trimmed = current.trim();
+    if (trimmed.isEmpty || trimmed == initial) return null;
+    return trimmed;
+  }
+
+  Future<void> _save() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+
+    final auth = context.read<AuthViewModel>();
+    final uid = auth.currentUser?.uid;
+    if (uid == null) return;
+
+    final firstName = _changedValue(_firstNameController.text, _initialFirstName);
+    final username = _changedValue(_usernameController.text, _initialUsername);
+    final phoneNumber = _changedValue(_phoneController.text, _initialPhone);
+
+    final navigator = context.read<NavigationProvider>();
+
+    if (firstName == null && username == null && phoneNumber == null) {
+      navigator.goBack();
+      return;
+    }
+
+    final result = await context.read<EditProfileViewModel>().saveProfile(
+      uid: uid,
+      firstName: firstName,
+      username: username,
+      phoneNumber: phoneNumber,
+    );
+
+    if (!mounted) return;
+
+    if (!result.isSuccess) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(result.error ?? AppStrings.editProfileSaveFailed)),
+      );
+      return;
+    }
+
+    await auth.loadCurrentUser();
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text(AppStrings.editProfileSaveSuccess)),
+    );
+    navigator.goBack();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final email = context.select<AuthViewModel, String?>(
+      (auth) => auth.userCredentials?.email,
+    );
+    final photoUrl = context.select<AuthViewModel, String?>(
+      (auth) => auth.userCredentials?.photoUrl,
+    );
+    final isSaving = context.watch<EditProfileViewModel>().isSaving;
+
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text(AppStrings.editProfileTitle),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(
+                  child: CircleAvatar(
+                    radius: 40,
+                    backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+                    backgroundImage: (photoUrl != null && photoUrl.isNotEmpty)
+                        ? NetworkImage(photoUrl)
+                        : AssetImage(AppImages.profileProfileIcon) as ImageProvider,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                TextFormField(
+                  controller: _firstNameController,
+                  enabled: !isSaving,
+                  textCapitalization: TextCapitalization.words,
+                  validator: _validateOptionalFirstName,
+                  decoration: const InputDecoration(
+                    labelText: AppStrings.editProfileFirstNameLabel,
+                    prefixIcon: Icon(Icons.badge_outlined),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _usernameController,
+                  enabled: !isSaving,
+                  validator: (value) {
+                    if ((value ?? '').trim().isEmpty) return null;
+                    return validateUsername(value);
+                  },
+                  decoration: const InputDecoration(
+                    labelText: AppStrings.editProfileUsernameLabel,
+                    prefixIcon: Icon(Icons.person_outline),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _phoneController,
+                  enabled: !isSaving,
+                  keyboardType: TextInputType.phone,
+                  validator: _validateOptionalPhone,
+                  decoration: const InputDecoration(
+                    labelText: AppStrings.editProfilePhoneLabel,
+                    prefixIcon: Icon(Icons.phone_outlined),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  enabled: false,
+                  initialValue: email ?? '',
+                  decoration: const InputDecoration(
+                    labelText: AppStrings.email,
+                    prefixIcon: Icon(Icons.email_outlined),
+                    helperText: AppStrings.editProfileEmailHelper,
+                  ),
+                ),
+                const SizedBox(height: 32),
+                // TODO: Change to BottomCTA when merged
+                SizedBox(
+                  height: 56,
+                  child: isSaving
+                      ? const Center(child: CircularProgressIndicator())
+                      : FilledButton(
+                          onPressed: _save,
+                          child: const Text(AppStrings.editProfileSave),
+                        ),
+                ),
+                SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/edit_profile_repository.dart
+++ b/lib/features/profile/edit_profile_repository.dart
@@ -1,0 +1,43 @@
+import 'package:cherry_mvp/core/config/config.dart';
+import 'package:cherry_mvp/core/services/services.dart';
+import 'package:cherry_mvp/core/utils/utils.dart';
+
+abstract class IEditProfileRepository {
+  Future<Result<void>> updateProfile({
+    String? displayName,
+    String? phoneNumber,
+  });
+}
+
+class EditProfileRepository implements IEditProfileRepository {
+  final ApiService apiService;
+
+  EditProfileRepository(this.apiService);
+
+  @override
+  Future<Result<void>> updateProfile({
+    String? displayName,
+    String? phoneNumber,
+  }) async {
+    final result = await apiService.put<Map<String, dynamic>>(
+      ApiEndpoints.profile,
+      data: {
+        'displayName': ?displayName,
+        'phoneNumber': ?phoneNumber,
+      },
+    );
+
+    if (!result.isSuccess) {
+      return Result.failure(result.error ?? AppStrings.editProfileSaveFailed);
+    }
+
+    final response = result.value;
+    if (response != null && response['success'] == false) {
+      return Result.failure(
+        response['message']?.toString() ?? AppStrings.editProfileSaveFailed,
+      );
+    }
+
+    return Result.success(null);
+  }
+}

--- a/lib/features/profile/edit_profile_view_model.dart
+++ b/lib/features/profile/edit_profile_view_model.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:cherry_mvp/core/config/config.dart';
+import 'package:cherry_mvp/core/services/services.dart';
+import 'package:cherry_mvp/core/utils/utils.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_repository.dart';
+
+class EditProfileViewModel extends ChangeNotifier {
+  final IEditProfileRepository repository;
+
+  EditProfileViewModel({required this.repository});
+
+  Status _status = Status.uninitialized;
+  Status get status => _status;
+  bool get isSaving => _status.type == StatusType.loading;
+
+  /// Saves the changed fields only; pass null for anything unchanged.
+  Future<Result<void>> saveProfile({
+    required String uid,
+    String? firstName,
+    String? username,
+    String? phoneNumber,
+  }) async {
+    if (isSaving) {
+      return Result.failure(AppStrings.editProfileSaveFailed);
+    }
+
+    _status = Status.loading;
+    notifyListeners();
+
+    try {
+      // Check username availability before writing anything.
+      if (username != null) {
+        final isTakenResult = await UsernameService.isUsernameTaken(
+          username,
+          excludeUid: uid,
+        );
+        if (!isTakenResult.isSuccess) {
+          return _fail(isTakenResult.error ?? AppStrings.editProfileSaveFailed);
+        }
+        if (isTakenResult.value == true) {
+          return _fail(AppStrings.usernameTakenError);
+        }
+      }
+
+      if (firstName != null || phoneNumber != null) {
+        final result = await repository.updateProfile(
+          displayName: firstName,
+          phoneNumber: phoneNumber,
+        );
+        if (!result.isSuccess) {
+          return _fail(result.error ?? AppStrings.editProfileSaveFailed);
+        }
+      }
+
+      if (username != null) {
+        final result = await UsernameService.saveUsername(uid, username);
+        if (!result.isSuccess) {
+          return _fail(result.error ?? AppStrings.usernameSaveFailed);
+        }
+      }
+
+      _status = Status.success;
+      notifyListeners();
+      return Result.success(null);
+    } catch (_) {
+      return _fail(AppStrings.editProfileSaveFailed);
+    }
+  }
+
+  Result<void> _fail(String message) {
+    _status = Status.failure(message);
+    notifyListeners();
+    return Result.failure(message);
+  }
+}

--- a/lib/features/profile/edit_profile_view_model.dart
+++ b/lib/features/profile/edit_profile_view_model.dart
@@ -4,14 +4,32 @@ import 'package:cherry_mvp/core/services/services.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
 import 'package:cherry_mvp/features/profile/edit_profile_repository.dart';
 
+typedef UsernameTakenCheck = Future<Result<bool>> Function(String username, {String? excludeUid});
+typedef UsernameSaver = Future<Result<void>> Function(String uid, String username);
+
 class EditProfileViewModel extends ChangeNotifier {
   final IEditProfileRepository repository;
+  final UsernameTakenCheck _isUsernameTaken;
+  final UsernameSaver _saveUsername;
 
-  EditProfileViewModel({required this.repository});
+  EditProfileViewModel({
+    required this.repository,
+    UsernameTakenCheck? isUsernameTaken,
+    UsernameSaver? saveUsername,
+  })  : _isUsernameTaken = isUsernameTaken ?? UsernameService.isUsernameTaken,
+        _saveUsername = saveUsername ?? UsernameService.saveUsername;
 
   Status _status = Status.uninitialized;
   Status get status => _status;
   bool get isSaving => _status.type == StatusType.loading;
+
+  bool _isPartialSave = false;
+
+  /// True when the name/phone write landed but the username write did not, so
+  /// the backend now holds changes the local user state does not know about.
+  /// The name and username live in different stores, so the two writes cannot
+  /// be made atomic here; the caller has to reload instead.
+  bool get isPartialSave => _isPartialSave;
 
   /// Saves the changed fields only; pass null for anything unchanged.
   Future<Result<void>> saveProfile({
@@ -25,15 +43,15 @@ class EditProfileViewModel extends ChangeNotifier {
     }
 
     _status = Status.loading;
+    _isPartialSave = false;
     notifyListeners();
+
+    var profileSaved = false;
 
     try {
       // Check username availability before writing anything.
       if (username != null) {
-        final isTakenResult = await UsernameService.isUsernameTaken(
-          username,
-          excludeUid: uid,
-        );
+        final isTakenResult = await _isUsernameTaken(username, excludeUid: uid);
         if (!isTakenResult.isSuccess) {
           return _fail(isTakenResult.error ?? AppStrings.editProfileSaveFailed);
         }
@@ -50,11 +68,17 @@ class EditProfileViewModel extends ChangeNotifier {
         if (!result.isSuccess) {
           return _fail(result.error ?? AppStrings.editProfileSaveFailed);
         }
+        profileSaved = true;
       }
 
       if (username != null) {
-        final result = await UsernameService.saveUsername(uid, username);
+        final result = await _saveUsername(uid, username);
         if (!result.isSuccess) {
+          // The name/phone write already landed, so report the partial outcome
+          // rather than implying nothing was saved.
+          if (profileSaved) {
+            return _fail(AppStrings.editProfileUsernameNotSaved, isPartial: true);
+          }
           return _fail(result.error ?? AppStrings.usernameSaveFailed);
         }
       }
@@ -63,12 +87,13 @@ class EditProfileViewModel extends ChangeNotifier {
       notifyListeners();
       return Result.success(null);
     } catch (_) {
-      return _fail(AppStrings.editProfileSaveFailed);
+      return _fail(AppStrings.editProfileSaveFailed, isPartial: profileSaved);
     }
   }
 
-  Result<void> _fail(String message) {
+  Result<void> _fail(String message, {bool isPartial = false}) {
     _status = Status.failure(message);
+    _isPartialSave = isPartial;
     notifyListeners();
     return Result.failure(message);
   }

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -111,6 +111,11 @@ class _ProfilePageState extends State<ProfilePage> {
       navigator.navigateTo(AppRoutes.likedItems);
     }
 
+    void navigateToEditProfile() {
+      final navigator = Provider.of<NavigationProvider>(context, listen: false);
+      navigator.navigateTo(AppRoutes.editProfile);
+    }
+
     return Scaffold(
       //profile header
       appBar: AppBar(
@@ -119,8 +124,7 @@ class _ProfilePageState extends State<ProfilePage> {
       ),
       body: SafeArea(
         child: RefreshIndicator(
-          onRefresh: () =>
-              context.read<ProfileListingsViewModel>().refreshListings(),
+          onRefresh: () => context.read<ProfileListingsViewModel>().refreshListings(),
           child: SingleChildScrollView(
             controller: _scrollController,
             physics: const AlwaysScrollableScrollPhysics(),
@@ -134,9 +138,9 @@ class _ProfilePageState extends State<ProfilePage> {
                   onSettingsPressed: () {
                     navigateToSettings();
                   },
+                  onProfilePressed: navigateToEditProfile,
                 ),
-                if (FeatureFlags.showProfileShortcutCards ||
-                    FeatureFlags.showDonorDiscounts)
+                if (FeatureFlags.showProfileShortcutCards || FeatureFlags.showDonorDiscounts)
                   UserOrderDetails(
                     onOrdersPressed: widget.onOrdersPressed,
                     onLikedPressed: navigateToLikedItems,

--- a/lib/features/profile/widgets/user_information_section.dart
+++ b/lib/features/profile/widgets/user_information_section.dart
@@ -11,11 +11,13 @@ import 'package:cherry_mvp/features/auth/auth_view_model.dart';
 class UserInformationSection extends StatelessWidget {
   final UserInformation userInformationSection;
   final VoidCallback onSettingsPressed;
+  final VoidCallback? onProfilePressed;
 
   const UserInformationSection({
     super.key,
     required this.userInformationSection,
     required this.onSettingsPressed,
+    this.onProfilePressed,
   });
 
   @override
@@ -52,6 +54,7 @@ class UserInformationSection extends StatelessWidget {
             const SizedBox(height: 8),
             ListTile(
               contentPadding: EdgeInsets.zero,
+              onTap: onProfilePressed,
               leading: Image.asset(
                 AppImages.profileProfileIcon,
                 height: 48,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -796,10 +796,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -812,10 +812,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1161,10 +1161,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/test/edit_profile_page_test.dart
+++ b/test/edit_profile_page_test.dart
@@ -1,0 +1,124 @@
+import 'package:cherry_mvp/core/config/app_strings.dart';
+import 'package:cherry_mvp/core/models/user.dart';
+import 'package:cherry_mvp/core/router/nav_provider.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/auth/auth_view_model.dart';
+import 'package:cherry_mvp/features/login/login_repository.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_page.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_repository.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_view_model.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+import 'support/unexpected_api_service.dart';
+
+class _MockLoginRepository extends Mock implements LoginRepository {}
+
+class _MockNavigationProvider extends Mock implements NavigationProvider {}
+
+class _MockFirebaseAuth extends Mock implements FirebaseAuth {}
+
+class _MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
+
+/// Stands in for the real view model so the page can be pumped without a
+/// Firestore-backed [AuthViewModel.loadCurrentUser].
+class _TestAuthViewModel extends AuthViewModel {
+  _TestAuthViewModel()
+      : super(
+          loginRepository: _MockLoginRepository(),
+          navigator: _MockNavigationProvider(),
+          firebaseAuth: _MockFirebaseAuth(),
+          firestore: _MockFirebaseFirestore(),
+          apiService: const UnexpectedApiService(),
+        );
+
+  void emitCredentials(UserCredentials credentials) {
+    userCredentials = credentials;
+    notifyListeners();
+  }
+}
+
+class _StubEditProfileRepository implements IEditProfileRepository {
+  @override
+  Future<Result<void>> updateProfile({
+    String? displayName,
+    String? phoneNumber,
+  }) async {
+    return Result.success(null);
+  }
+}
+
+Widget _wrap(AuthViewModel auth) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<AuthViewModel>.value(value: auth),
+      Provider<NavigationProvider>.value(value: _MockNavigationProvider()),
+      ChangeNotifierProvider<EditProfileViewModel>(
+        create: (_) => EditProfileViewModel(repository: _StubEditProfileRepository()),
+      ),
+    ],
+    child: const MaterialApp(home: EditProfilePage()),
+  );
+}
+
+Finder _fieldWithLabel(String label) {
+  return find.ancestor(
+    of: find.text(label),
+    matching: find.byType(TextFormField),
+  );
+}
+
+String _valueOf(WidgetTester tester, String label) {
+  return tester.widget<EditableText>(
+    find.descendant(of: _fieldWithLabel(label), matching: find.byType(EditableText)),
+  ).controller.text;
+}
+
+final _credentials = UserCredentials(
+  uid: 'uid-1',
+  email: 'josh@example.com',
+  username: 'josh',
+  firstname: 'Joshua',
+  phoneNumber: '07123456789',
+);
+
+void main() {
+  group('EditProfilePage', () {
+    testWidgets('shows a loading state until the profile has loaded',
+        (tester) async {
+      final auth = _TestAuthViewModel();
+
+      await tester.pumpWidget(_wrap(auth));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(TextFormField), findsNothing);
+
+      auth.emitCredentials(_credentials);
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(_valueOf(tester, AppStrings.editProfileFirstNameLabel), 'Joshua');
+      expect(_valueOf(tester, AppStrings.editProfileUsernameLabel), 'josh');
+      expect(_valueOf(tester, AppStrings.editProfilePhoneLabel), '07123456789');
+      expect(_valueOf(tester, AppStrings.email), 'josh@example.com');
+    });
+
+    testWidgets('shows the email as read-only', (tester) async {
+      final auth = _TestAuthViewModel();
+
+      await tester.pumpWidget(_wrap(auth));
+      auth.emitCredentials(_credentials);
+      await tester.pump();
+
+      final email = tester.widget<TextField>(
+        find.descendant(of: _fieldWithLabel(AppStrings.email), matching: find.byType(TextField)),
+      );
+
+      expect(email.enabled, isFalse);
+    });
+  });
+}

--- a/test/edit_profile_view_model_test.dart
+++ b/test/edit_profile_view_model_test.dart
@@ -1,3 +1,4 @@
+import 'package:cherry_mvp/core/config/app_strings.dart';
 import 'package:cherry_mvp/core/utils/result.dart';
 import 'package:cherry_mvp/core/utils/status.dart';
 import 'package:cherry_mvp/features/profile/edit_profile_repository.dart';
@@ -67,6 +68,43 @@ void main() {
 
       expect(result.isSuccess, isTrue);
       expect(repository.updateCount, 0);
+    });
+
+    test('reports a partial save when the username write fails after the profile write',
+        () async {
+      final repository = _FakeEditProfileRepository();
+      final viewModel = EditProfileViewModel(
+        repository: repository,
+        isUsernameTaken: (username, {excludeUid}) async => Result.success(false),
+        saveUsername: (uid, username) async => Result.failure('firestore down'),
+      );
+
+      final result = await viewModel.saveProfile(
+        uid: 'uid-1',
+        firstName: 'Joshua',
+        username: 'josh',
+      );
+
+      expect(result.isSuccess, isFalse);
+      expect(result.error, AppStrings.editProfileUsernameNotSaved);
+      expect(repository.updateCount, 1);
+      expect(viewModel.isPartialSave, isTrue);
+    });
+
+    test('a username-only failure is not a partial save', () async {
+      final repository = _FakeEditProfileRepository();
+      final viewModel = EditProfileViewModel(
+        repository: repository,
+        isUsernameTaken: (username, {excludeUid}) async => Result.success(false),
+        saveUsername: (uid, username) async => Result.failure('firestore down'),
+      );
+
+      final result = await viewModel.saveProfile(uid: 'uid-1', username: 'josh');
+
+      expect(result.isSuccess, isFalse);
+      expect(result.error, 'firestore down');
+      expect(repository.updateCount, 0);
+      expect(viewModel.isPartialSave, isFalse);
     });
 
     test('surfaces repository failures', () async {

--- a/test/edit_profile_view_model_test.dart
+++ b/test/edit_profile_view_model_test.dart
@@ -1,0 +1,88 @@
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/core/utils/status.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_repository.dart';
+import 'package:cherry_mvp/features/profile/edit_profile_view_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeEditProfileRepository implements IEditProfileRepository {
+  _FakeEditProfileRepository({Result<void>? updateResult})
+      : updateResult = updateResult ?? Result.success(null);
+
+  Result<void> updateResult;
+  int updateCount = 0;
+  String? lastDisplayName;
+  String? lastPhoneNumber;
+
+  @override
+  Future<Result<void>> updateProfile({
+    String? displayName,
+    String? phoneNumber,
+  }) async {
+    updateCount += 1;
+    lastDisplayName = displayName;
+    lastPhoneNumber = phoneNumber;
+    return updateResult;
+  }
+}
+
+void main() {
+  group('EditProfileViewModel', () {
+    test('sends changed fields to the repository and reports success',
+        () async {
+      final repository = _FakeEditProfileRepository();
+      final viewModel = EditProfileViewModel(repository: repository);
+
+      final result = await viewModel.saveProfile(
+        uid: 'uid-1',
+        firstName: 'Joshua',
+        phoneNumber: '07123456789',
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(repository.updateCount, 1);
+      expect(repository.lastDisplayName, 'Joshua');
+      expect(repository.lastPhoneNumber, '07123456789');
+      expect(viewModel.status.type, StatusType.success);
+    });
+
+    test('only sends the fields that changed', () async {
+      final repository = _FakeEditProfileRepository();
+      final viewModel = EditProfileViewModel(repository: repository);
+
+      final result = await viewModel.saveProfile(
+        uid: 'uid-1',
+        phoneNumber: '07123456789',
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(repository.lastDisplayName, isNull);
+      expect(repository.lastPhoneNumber, '07123456789');
+    });
+
+    test('does not call the repository when nothing changed', () async {
+      final repository = _FakeEditProfileRepository();
+      final viewModel = EditProfileViewModel(repository: repository);
+
+      final result = await viewModel.saveProfile(uid: 'uid-1');
+
+      expect(result.isSuccess, isTrue);
+      expect(repository.updateCount, 0);
+    });
+
+    test('surfaces repository failures', () async {
+      final repository = _FakeEditProfileRepository(
+        updateResult: Result.failure('server unavailable'),
+      );
+      final viewModel = EditProfileViewModel(repository: repository);
+
+      final result = await viewModel.saveProfile(
+        uid: 'uid-1',
+        firstName: 'Joshua',
+      );
+
+      expect(result.isSuccess, isFalse);
+      expect(result.error, 'server unavailable');
+      expect(viewModel.status.type, StatusType.failure);
+    });
+  });
+}


### PR DESCRIPTION
 - I wanted to change my phone number but had no way of doing it so I added this page
 - On the profile page, when a user presses on their profile row, it takes them to an edit profile page
 - Backend needs to be merged before this PR can be merged https://github.com/Cherry-CIC/cherry-Backend/pull/48
 - This should work once the backend is merged in & deployed ^

<video src="https://github.com/user-attachments/assets/66863285-41ae-409e-b6cd-b6495742b56e"></video>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Edit Profile screen for updating first name, username, and phone number.
  - Email is displayed as read-only with guidance.
  - Added username availability checks, validation, success and error feedback, and automatic profile refresh.
  - Reports when profile details save successfully but the username update fails.
  - Added navigation to Edit Profile from the Profile screen.

- **Tests**
  - Added coverage for loading user details, read-only email, successful updates, failures, unchanged fields, and partial saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->