### PR TITLE
#475 pull request: feat(orders): add buyer confirmation and dispute flow

### DIFF
--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -78,6 +78,9 @@ class AppStrings {
   static const myOrdersLoadFailed = 'We could not load your orders. Please try again.';
   static const myOrdersRefreshFailed = 'We could not refresh your orders.';
   static const myOrdersStatusUnavailable = 'Status unavailable';
+  static const myOrdersAwaitingConfirmation = 'Awaiting confirmation';
+  static const myOrdersConfirmed = 'Confirmed';
+  static const myOrdersDisputed = 'Disputed';
   static const myOrdersPriceUnavailable = 'Price unavailable';
   static const myOrdersSizeUnavailable = 'Size unavailable';
   static const likedItemsTitle = 'Liked Items ❤️';

--- a/lib/core/config/app_strings.dart
+++ b/lib/core/config/app_strings.dart
@@ -79,6 +79,7 @@ class AppStrings {
   static const myOrdersRefreshFailed = 'We could not refresh your orders.';
   static const myOrdersStatusUnavailable = 'Status unavailable';
   static const myOrdersAwaitingConfirmation = 'Awaiting confirmation';
+    static const myOrdersOther = 'Other orders';
   static const myOrdersConfirmed = 'Confirmed';
   static const myOrdersDisputed = 'Disputed';
   static const myOrdersPriceUnavailable = 'Price unavailable';

--- a/lib/core/services/network/api_endpoints.dart
+++ b/lib/core/services/network/api_endpoints.dart
@@ -22,6 +22,14 @@ class ApiEndpoints {
   static const String paymentIntent = '$_apiPrefix/payment/create-payment-intent';
   static const String createOrder = '$_apiPrefix/order/create';
   static const String myOrders = '$_apiPrefix/order/my-orders';
+  static String confirmOrderReceived(String orderId) {
+    return '$_apiPrefix/order/${Uri.encodeComponent(orderId)}/confirm-received';
+  }
+
+  static String disputeOrder(String orderId) {
+    return '$_apiPrefix/order/${Uri.encodeComponent(orderId)}/dispute';
+  }
+
   static String productById(String productId) {
     return '$products/${Uri.encodeComponent(productId)}';
   }

--- a/lib/features/orders/models/order_summary.dart
+++ b/lib/features/orders/models/order_summary.dart
@@ -41,12 +41,13 @@ class OrderSummary {
 
     final productId = _readString(json['productId']);
     final productName = _readString(json['productName']);
+    final imageUrl = _readString(json['imageUrl']);
 
     return OrderSummary(
       id: id,
       productId: productId,
       productName: productName.isEmpty ? fallbackProductName : productName,
-      imageUrl: '',
+      imageUrl: imageUrl,
       size: '',
       charityLogoUrl: '',
       itemPriceMinor: _readNonNegativeInteger(json['productAmount']),

--- a/lib/features/orders/models/order_summary.dart
+++ b/lib/features/orders/models/order_summary.dart
@@ -70,6 +70,8 @@ class OrderSummary {
     String? imageUrl,
     String? size,
     String? charityLogoUrl,
+    String? deliveryState,
+    String? deliveryLabel,
   }) {
     return OrderSummary(
       id: id,
@@ -81,8 +83,8 @@ class OrderSummary {
       itemPriceMinor: itemPriceMinor,
       totalAmountMinor: totalAmountMinor,
       currency: currency,
-      deliveryState: deliveryState,
-      deliveryLabel: deliveryLabel,
+      deliveryState: deliveryState ?? this.deliveryState,
+      deliveryLabel: deliveryLabel ?? this.deliveryLabel,
     );
   }
 

--- a/lib/features/orders/orders_page.dart
+++ b/lib/features/orders/orders_page.dart
@@ -1,5 +1,6 @@
 import 'package:cherry_mvp/core/config/app_strings.dart';
 import 'package:cherry_mvp/core/utils/status.dart';
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
 import 'package:cherry_mvp/features/orders/orders_view_model.dart';
 import 'package:cherry_mvp/features/orders/widgets/order_card.dart';
 import 'package:flutter/material.dart';
@@ -40,6 +41,69 @@ class _MyOrdersPageState extends State<MyOrdersPage> {
   void dispose() {
     _viewModel?.clearOrders(notify: false);
     super.dispose();
+  }
+
+  Future<void> _handleOrderTap(BuildContext context, OrderSummary order) async {
+    final state = order.deliveryState.trim().toLowerCase();
+    if (state != 'awaiting_confirmation' && state != 'delivered') {
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => _ConfirmItemDialog(order: order),
+    );
+
+    if (!mounted || confirmed != true) {
+      return;
+    }
+
+    final result = await _viewModel?.confirmOrderReceived(order.id);
+    if (!mounted) {
+      return;
+    }
+
+    if (result?.isSuccess == true) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Receipt confirmed')),
+      );
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(result?.error ?? 'Could not confirm this item')),
+    );
+  }
+
+  Future<void> _openDisputeDialog(BuildContext context, OrderSummary order) async {
+    final result = await showDialog<_DisputeChoice>(
+      context: context,
+      builder: (dialogContext) => _DisputeDialog(order: order),
+    );
+
+    if (!mounted || result == null) {
+      return;
+    }
+
+    final submitResult = await _viewModel?.submitOrderDispute(
+      order.id,
+      reason: result.reason,
+      message: result.message,
+    );
+    if (!mounted) {
+      return;
+    }
+
+    if (submitResult?.isSuccess == true) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Dispute submitted')),
+      );
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(submitResult?.error ?? 'Could not submit the dispute')),
+    );
   }
 
   @override
@@ -204,12 +268,190 @@ class _OrdersList extends StatelessWidget {
           }
 
           final orderIndex = index - (hasRefreshError ? 1 : 0);
+          final order = viewModel.orders[orderIndex];
           return OrderCard(
-            key: ValueKey(viewModel.orders[orderIndex].id),
-            order: viewModel.orders[orderIndex],
+            key: ValueKey(order.id),
+            order: order,
+            onTap: () => _OrdersListState.handleOrderAction(context, order, viewModel),
           );
         },
       ),
+    );
+  }
+}
+
+class _ConfirmItemDialog extends StatelessWidget {
+  final OrderSummary order;
+
+  const _ConfirmItemDialog({required this.order});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final orderImage = order.imageUrl.trim().isNotEmpty
+        ? ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: SizedBox(
+              height: 180,
+              width: double.infinity,
+              child: Image.network(
+                order.imageUrl,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+              ),
+            ),
+          )
+        : const SizedBox.shrink();
+
+    return AlertDialog(
+      title: const Text('Confirm this item'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (orderImage is! SizedBox || order.imageUrl.trim().isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: orderImage,
+            ),
+          Text(
+            order.productName,
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          const Text('Have you received your item as expected?'),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        OutlinedButton(
+          onPressed: () {
+            Navigator.of(context).pop(false);
+            final pageState = context.findAncestorStateOfType<_MyOrdersPageState>();
+            pageState?._openDisputeDialog(context, order);
+          },
+          child: const Text('Raise dispute'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Yes, all good'),
+        ),
+      ],
+    );
+  }
+}
+
+class _DisputeChoice {
+  final String reason;
+  final String message;
+
+  const _DisputeChoice({required this.reason, required this.message});
+}
+
+class _DisputeDialog extends StatefulWidget {
+  final OrderSummary order;
+
+  const _DisputeDialog({required this.order});
+
+  @override
+  State<_DisputeDialog> createState() => _DisputeDialogState();
+}
+
+class _DisputeDialogState extends State<_DisputeDialog> {
+  String _reason = 'wrong_item';
+  final TextEditingController _messageController = TextEditingController();
+
+  @override
+  void dispose() {
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Raise dispute'),
+      content: SizedBox(
+        width: 420,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            DropdownButtonFormField<String>(
+              value: _reason,
+              items: const [
+                DropdownMenuItem(value: 'wrong_item', child: Text('Wrong item')),
+                DropdownMenuItem(value: 'item_not_as_described', child: Text('Item not as described')),
+                DropdownMenuItem(value: 'item_arrived_damaged', child: Text('Item arrived damaged')),
+                DropdownMenuItem(value: 'something_else', child: Text('Something else')),
+              ],
+              onChanged: (value) => setState(() => _reason = value ?? _reason),
+              decoration: const InputDecoration(labelText: 'Reason'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _messageController,
+              maxLines: 4,
+              decoration: const InputDecoration(
+                labelText: 'Tell us what went wrong',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(
+            _DisputeChoice(
+              reason: _reason,
+              message: _messageController.text,
+            ),
+          ),
+          child: const Text('Submit'),
+        ),
+      ],
+    );
+  }
+}
+
+class _OrdersListState {
+  static Future<void> handleOrderAction(
+    BuildContext context,
+    OrderSummary order,
+    OrdersViewModel viewModel,
+  ) async {
+    final state = order.deliveryState.trim().toLowerCase();
+    if (state != 'awaiting_confirmation' && state != 'delivered') {
+      return;
+    }
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => _ConfirmItemDialog(order: order),
+    );
+    if (result != true) {
+      return;
+    }
+
+    final confirmResult = await viewModel.confirmOrderReceived(order.id);
+    if (!context.mounted) {
+      return;
+    }
+    if (confirmResult.isSuccess) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Receipt confirmed')),
+      );
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(confirmResult.error ?? 'Could not confirm this item')),
     );
   }
 }

--- a/lib/features/orders/orders_page.dart
+++ b/lib/features/orders/orders_page.dart
@@ -260,28 +260,67 @@ class _OrdersList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hasRefreshError = viewModel.refreshError != null;
+    final awaitingConfirmationOrders = viewModel.orders
+        .where((order) => order.deliveryState.trim().toLowerCase() == 'awaiting_confirmation')
+        .toList(growable: false);
+    final otherOrders = viewModel.orders
+        .where((order) => order.deliveryState.trim().toLowerCase() != 'awaiting_confirmation')
+        .toList(growable: false);
+    final children = <Widget>[
+      if (hasRefreshError) _RefreshFailure(onRetry: viewModel.refreshOrders),
+      if (awaitingConfirmationOrders.isNotEmpty) ...[
+        const _OrderSectionHeader(title: AppStrings.myOrdersAwaitingConfirmation),
+        ...awaitingConfirmationOrders.map(
+          (order) => _OrderListItem(order: order, viewModel: viewModel),
+        ),
+      ],
+      if (otherOrders.isNotEmpty) ...[
+        const _OrderSectionHeader(title: AppStrings.myOrdersOther),
+        ...otherOrders.map(
+          (order) => _OrderListItem(order: order, viewModel: viewModel),
+        ),
+      ],
+    ];
 
     return RefreshIndicator(
       onRefresh: viewModel.refreshOrders,
       child: ListView.separated(
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-        itemCount: viewModel.orders.length + (hasRefreshError ? 1 : 0),
+        itemCount: children.length,
         separatorBuilder: (_, _) => const SizedBox(height: 24),
-        itemBuilder: (context, index) {
-          if (hasRefreshError && index == 0) {
-            return _RefreshFailure(onRetry: viewModel.refreshOrders);
-          }
-
-          final orderIndex = index - (hasRefreshError ? 1 : 0);
-          final order = viewModel.orders[orderIndex];
-          return OrderCard(
-            key: ValueKey(order.id),
-            order: order,
-            onTap: () => _OrdersListState.handleOrderAction(context, order, viewModel),
-          );
-        },
+        itemBuilder: (_, index) => children[index],
       ),
+    );
+  }
+}
+
+class _OrderSectionHeader extends StatelessWidget {
+  final String title;
+
+  const _OrderSectionHeader({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(title, style: Theme.of(context).textTheme.titleMedium);
+  }
+}
+
+class _OrderListItem extends StatelessWidget {
+  final OrderSummary order;
+  final OrdersViewModel viewModel;
+
+  const _OrderListItem({
+    required this.order,
+    required this.viewModel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return OrderCard(
+      key: ValueKey(order.id),
+      order: order,
+      onTap: () => _OrdersListState.handleOrderAction(context, order, viewModel),
     );
   }
 }

--- a/lib/features/orders/orders_page.dart
+++ b/lib/features/orders/orders_page.dart
@@ -49,12 +49,17 @@ class _MyOrdersPageState extends State<MyOrdersPage> {
       return;
     }
 
-    final confirmed = await showDialog<bool>(
+    final action = await showDialog<_ConfirmItemAction>(
       context: context,
       builder: (dialogContext) => _ConfirmItemDialog(order: order),
     );
 
-    if (!mounted || confirmed != true) {
+    if (!mounted || action == null) {
+      return;
+    }
+
+    if (action == _ConfirmItemAction.dispute) {
+      await _openDisputeDialog(context, order);
       return;
     }
 
@@ -280,6 +285,8 @@ class _OrdersList extends StatelessWidget {
   }
 }
 
+enum _ConfirmItemAction { confirm, dispute }
+
 class _ConfirmItemDialog extends StatelessWidget {
   final OrderSummary order;
 
@@ -328,15 +335,11 @@ class _ConfirmItemDialog extends StatelessWidget {
           child: const Text('Cancel'),
         ),
         OutlinedButton(
-          onPressed: () {
-            Navigator.of(context).pop(false);
-            final pageState = context.findAncestorStateOfType<_MyOrdersPageState>();
-            pageState?._openDisputeDialog(context, order);
-          },
+          onPressed: () => Navigator.of(context).pop(_ConfirmItemAction.dispute),
           child: const Text('Raise dispute'),
         ),
         FilledButton(
-          onPressed: () => Navigator.of(context).pop(true),
+          onPressed: () => Navigator.of(context).pop(_ConfirmItemAction.confirm),
           child: const Text('Yes, all good'),
         ),
       ],
@@ -432,11 +435,42 @@ class _OrdersListState {
       return;
     }
 
-    final result = await showDialog<bool>(
+    final action = await showDialog<_ConfirmItemAction>(
       context: context,
       builder: (dialogContext) => _ConfirmItemDialog(order: order),
     );
-    if (result != true) {
+    if (action == null) {
+      return;
+    }
+
+    if (action == _ConfirmItemAction.dispute) {
+      final disputeChoice = await showDialog<_DisputeChoice>(
+        context: context,
+        builder: (dialogContext) => _DisputeDialog(order: order),
+      );
+      if (disputeChoice == null) {
+        return;
+      }
+
+      final disputeResult = await viewModel.submitOrderDispute(
+        order.id,
+        reason: disputeChoice.reason,
+        message: disputeChoice.message,
+      );
+      if (!context.mounted) {
+        return;
+      }
+      if (disputeResult.isSuccess) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Dispute submitted')),
+        );
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(disputeResult.error ?? 'Could not submit the dispute'),
+        ),
+      );
       return;
     }
 

--- a/lib/features/orders/orders_page.dart
+++ b/lib/features/orders/orders_page.dart
@@ -2,6 +2,7 @@ import 'package:cherry_mvp/core/config/app_strings.dart';
 import 'package:cherry_mvp/core/utils/status.dart';
 import 'package:cherry_mvp/features/orders/models/order_summary.dart';
 import 'package:cherry_mvp/features/orders/orders_view_model.dart';
+import 'package:cherry_mvp/features/orders/widgets/confirm_item_dialog.dart';
 import 'package:cherry_mvp/features/orders/widgets/order_card.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -49,16 +50,16 @@ class _MyOrdersPageState extends State<MyOrdersPage> {
       return;
     }
 
-    final action = await showDialog<_ConfirmItemAction>(
+    final action = await showDialog<ConfirmItemAction>(
       context: context,
-      builder: (dialogContext) => _ConfirmItemDialog(order: order),
+      builder: (dialogContext) => ConfirmItemDialog(order: order),
     );
 
     if (!mounted || action == null) {
       return;
     }
 
-    if (action == _ConfirmItemAction.dispute) {
+    if (action == ConfirmItemAction.dispute) {
       await _openDisputeDialog(context, order);
       return;
     }
@@ -285,68 +286,6 @@ class _OrdersList extends StatelessWidget {
   }
 }
 
-enum _ConfirmItemAction { confirm, dispute }
-
-class _ConfirmItemDialog extends StatelessWidget {
-  final OrderSummary order;
-
-  const _ConfirmItemDialog({required this.order});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final orderImage = order.imageUrl.trim().isNotEmpty
-        ? ClipRRect(
-            borderRadius: BorderRadius.circular(12),
-            child: SizedBox(
-              height: 180,
-              width: double.infinity,
-              child: Image.network(
-                order.imageUrl,
-                fit: BoxFit.cover,
-                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
-              ),
-            ),
-          )
-        : const SizedBox.shrink();
-
-    return AlertDialog(
-      title: const Text('Confirm this item'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (orderImage is! SizedBox || order.imageUrl.trim().isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(bottom: 16),
-              child: orderImage,
-            ),
-          Text(
-            order.productName,
-            style: theme.textTheme.titleMedium,
-          ),
-          const SizedBox(height: 16),
-          const Text('Have you received your item as expected?'),
-        ],
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(false),
-          child: const Text('Cancel'),
-        ),
-        OutlinedButton(
-          onPressed: () => Navigator.of(context).pop(_ConfirmItemAction.dispute),
-          child: const Text('Raise dispute'),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.of(context).pop(_ConfirmItemAction.confirm),
-          child: const Text('Yes, all good'),
-        ),
-      ],
-    );
-  }
-}
-
 class _DisputeChoice {
   final String reason;
   final String message;
@@ -435,15 +374,15 @@ class _OrdersListState {
       return;
     }
 
-    final action = await showDialog<_ConfirmItemAction>(
+    final action = await showDialog<ConfirmItemAction>(
       context: context,
-      builder: (dialogContext) => _ConfirmItemDialog(order: order),
+      builder: (dialogContext) => ConfirmItemDialog(order: order),
     );
     if (action == null) {
       return;
     }
 
-    if (action == _ConfirmItemAction.dispute) {
+    if (action == ConfirmItemAction.dispute) {
       final disputeChoice = await showDialog<_DisputeChoice>(
         context: context,
         builder: (dialogContext) => _DisputeDialog(order: order),

--- a/lib/features/orders/orders_repository.dart
+++ b/lib/features/orders/orders_repository.dart
@@ -6,6 +6,12 @@ import 'package:cherry_mvp/features/orders/models/order_summary.dart';
 
 abstract class IOrdersRepository {
   Future<Result<List<OrderSummary>>> fetchOrders();
+  Future<Result<dynamic>> confirmOrderReceived(String orderId);
+  Future<Result<dynamic>> submitOrderDispute(
+    String orderId, {
+    required String reason,
+    String? message,
+  });
 }
 
 final class OrdersRepository implements IOrdersRepository {
@@ -14,6 +20,47 @@ final class OrdersRepository implements IOrdersRepository {
   final ApiService _apiService;
 
   OrdersRepository(this._apiService);
+
+  @override
+  Future<Result<dynamic>> confirmOrderReceived(String orderId) async {
+    try {
+      final result = await _apiService.post<dynamic>(
+        ApiEndpoints.confirmOrderReceived(orderId),
+      );
+      if (!result.isSuccess || result.value == null) {
+        return Result.failure(result.error ?? 'Could not confirm this item');
+      }
+      return Result.success(result.value);
+    } catch (_) {
+      return Result.failure('Could not confirm this item');
+    }
+  }
+
+  @override
+  Future<Result<dynamic>> submitOrderDispute(
+    String orderId, {
+    required String reason,
+    String? message,
+  }) async {
+    try {
+      final payload = <String, dynamic>{'reason': reason};
+      final trimmedMessage = (message ?? '').trim();
+      if (trimmedMessage.isNotEmpty) {
+        payload['message'] = trimmedMessage;
+      }
+
+      final result = await _apiService.post<dynamic>(
+        ApiEndpoints.disputeOrder(orderId),
+        data: payload,
+      );
+      if (!result.isSuccess || result.value == null) {
+        return Result.failure(result.error ?? 'Could not submit the dispute');
+      }
+      return Result.success(result.value);
+    } catch (_) {
+      return Result.failure('Could not submit the dispute');
+    }
+  }
 
   @override
   Future<Result<List<OrderSummary>>> fetchOrders() async {

--- a/lib/features/orders/orders_view_model.dart
+++ b/lib/features/orders/orders_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:cherry_mvp/core/utils/result.dart';
 import 'package:cherry_mvp/core/utils/status.dart';
 import 'package:cherry_mvp/features/orders/models/order_summary.dart';
 import 'package:cherry_mvp/features/orders/orders_repository.dart';
@@ -32,6 +33,52 @@ class OrdersViewModel extends ChangeNotifier {
 
   Future<void> retryLoad() async {
     await _fetchOrders(clearExistingOrders: true);
+  }
+
+  Future<Result<dynamic>> confirmOrderReceived(String orderId) async {
+    final result = await repository.confirmOrderReceived(orderId);
+    if (result.isSuccess) {
+      _orders = _orders
+          .map((order) {
+            if (order.id != orderId) {
+              return order;
+            }
+            return order.copyWith(
+              deliveryState: 'confirmed',
+              deliveryLabel: 'Confirmed',
+            );
+          })
+          .toList(growable: false);
+      _notifyIfActive();
+    }
+    return result;
+  }
+
+  Future<Result<dynamic>> submitOrderDispute(
+    String orderId, {
+    required String reason,
+    String? message,
+  }) async {
+    final result = await repository.submitOrderDispute(
+      orderId,
+      reason: reason,
+      message: message,
+    );
+    if (result.isSuccess) {
+      _orders = _orders
+          .map((order) {
+            if (order.id != orderId) {
+              return order;
+            }
+            return order.copyWith(
+              deliveryState: 'disputed',
+              deliveryLabel: 'Disputed',
+            );
+          })
+          .toList(growable: false);
+      _notifyIfActive();
+    }
+    return result;
   }
 
   void clearOrders({bool notify = true}) {

--- a/lib/features/orders/widgets/confirm_item_dialog.dart
+++ b/lib/features/orders/widgets/confirm_item_dialog.dart
@@ -1,0 +1,65 @@
+import 'package:cherry_mvp/features/orders/models/order_summary.dart';
+import 'package:flutter/material.dart';
+
+enum ConfirmItemAction { confirm, dispute }
+
+class ConfirmItemDialog extends StatelessWidget {
+  final OrderSummary order;
+
+  const ConfirmItemDialog({
+    super.key,
+    required this.order,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasOrderImage = order.imageUrl.trim().isNotEmpty;
+
+    return AlertDialog(
+      title: const Text('Confirm this item'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (hasOrderImage)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: SizedBox(
+                  height: 180,
+                  width: double.infinity,
+                  child: Image.network(
+                    order.imageUrl,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                  ),
+                ),
+              ),
+            ),
+          Text(
+            order.productName,
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          const Text('Have you received your item as expected?'),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        OutlinedButton(
+          onPressed: () => Navigator.of(context).pop(ConfirmItemAction.dispute),
+          child: const Text('Raise dispute'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(ConfirmItemAction.confirm),
+          child: const Text('Yes, all good'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/orders/widgets/order_card.dart
+++ b/lib/features/orders/widgets/order_card.dart
@@ -6,10 +6,12 @@ import 'package:flutter/material.dart';
 
 class OrderCard extends StatelessWidget {
   final OrderSummary order;
+  final VoidCallback? onTap;
 
   const OrderCard({
     super.key,
     required this.order,
+    this.onTap,
   });
 
   @override
@@ -24,41 +26,47 @@ class OrderCard extends StatelessWidget {
           '${order.productName}. Size $sizeLabel. '
           '$priceLabel. $statusLabel.',
       child: ExcludeSemantics(
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final textScale = MediaQuery.textScalerOf(context).scale(1);
-            final useFlexibleLayout = constraints.maxWidth < 340 || textScale > 1.3;
-            final imageSize = useFlexibleLayout ? 112.0 : (constraints.maxWidth * 0.36).clamp(120.0, 144.0).toDouble();
+        child: GestureDetector(
+          onTap: onTap,
+          behavior: HitTestBehavior.opaque,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final textScale = MediaQuery.textScalerOf(context).scale(1);
+              final useFlexibleLayout = constraints.maxWidth < 340 || textScale > 1.3;
+              final imageSize = useFlexibleLayout
+                  ? 112.0
+                  : (constraints.maxWidth * 0.36).clamp(120.0, 144.0).toDouble();
 
-            if (useFlexibleLayout) {
-              return _FlexibleOrderLayout(
-                order: order,
-                imageSize: imageSize,
-                sizeLabel: sizeLabel,
-                priceLabel: priceLabel,
-                statusLabel: statusLabel,
-              );
-            }
+              if (useFlexibleLayout) {
+                return _FlexibleOrderLayout(
+                  order: order,
+                  imageSize: imageSize,
+                  sizeLabel: sizeLabel,
+                  priceLabel: priceLabel,
+                  statusLabel: statusLabel,
+                );
+              }
 
-            return Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _OrderImage(order: order, size: imageSize),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(minHeight: imageSize),
-                    child: _OrderDetails(
-                      order: order,
-                      sizeLabel: sizeLabel,
-                      priceLabel: priceLabel,
-                      statusLabel: statusLabel,
+              return Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _OrderImage(order: order, size: imageSize),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(minHeight: imageSize),
+                      child: _OrderDetails(
+                        order: order,
+                        sizeLabel: sizeLabel,
+                        priceLabel: priceLabel,
+                        statusLabel: statusLabel,
+                      ),
                     ),
                   ),
-                ),
-              ],
-            );
-          },
+                ],
+              );
+            },
+          ),
         ),
       ),
     );
@@ -368,6 +376,9 @@ class OrderStatusFormatter {
       'dispatched' || 'shipped' || 'in_transit' => 'On the way',
       'out_for_delivery' => 'Out for delivery',
       'delivered' => 'Delivered',
+      'awaiting_confirmation' => AppStrings.myOrdersAwaitingConfirmation,
+      'confirmed' => AppStrings.myOrdersConfirmed,
+      'disputed' => AppStrings.myOrdersDisputed,
       'cancelled' || 'canceled' => 'Cancelled',
       'returned' => 'Returned',
       'refunded' => 'Refunded',

--- a/test/orders_repository_test.dart
+++ b/test/orders_repository_test.dart
@@ -8,12 +8,20 @@ import 'package:cherry_mvp/features/orders/orders_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 typedef _GetHandler = FutureOr<Result<dynamic>> Function(String endpoint);
+typedef _PostHandler = FutureOr<Result<dynamic>> Function(
+  String endpoint,
+  dynamic data,
+);
 
 class _FakeApiService implements ApiService {
   final _GetHandler _handler;
+  final _PostHandler? _postHandler;
   final List<String> requestedEndpoints = [];
+  String? postedEndpoint;
+  dynamic postedData;
 
-  _FakeApiService(this._handler);
+  _FakeApiService(this._handler, { _PostHandler? postHandler })
+      : _postHandler = postHandler;
 
   @override
   Future<Result<T>> get<T>(
@@ -22,6 +30,17 @@ class _FakeApiService implements ApiService {
   }) async {
     requestedEndpoints.add(endpoint);
     final result = await _handler(endpoint);
+    if (!result.isSuccess) {
+      return Result.failure(result.error);
+    }
+    return Result.success(result.value as T);
+  }
+
+  @override
+  Future<Result<T>> post<T>(String endpoint, {dynamic data}) async {
+    postedEndpoint = endpoint;
+    postedData = data;
+    final result = await _postHandler?.call(endpoint, data) ?? Result.failure('Unexpected POST');
     if (!result.isSuccess) {
       return Result.failure(result.error);
     }
@@ -111,6 +130,54 @@ void main() {
   });
 
   group('OrdersRepository', () {
+    test('posts receipt confirmation without a request body', () async {
+      final apiService = _FakeApiService(
+        (_) => Result.failure('Unexpected GET'),
+        postHandler: (_, __) => Result.success({}),
+      );
+
+      final result = await OrdersRepository(apiService).confirmOrderReceived('order / one');
+
+      expect(result.isSuccess, isTrue);
+      expect(apiService.postedEndpoint, ApiEndpoints.confirmOrderReceived('order / one'));
+      expect(apiService.postedData, isNull);
+    });
+
+    test('posts a trimmed dispute message and required reason', () async {
+      final apiService = _FakeApiService(
+        (_) => Result.failure('Unexpected GET'),
+        postHandler: (_, __) => Result.success({}),
+      );
+
+      final result = await OrdersRepository(apiService).submitOrderDispute(
+        'order-1',
+        reason: 'item_arrived_damaged',
+        message: '  Damaged sleeve.  ',
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(apiService.postedEndpoint, ApiEndpoints.disputeOrder('order-1'));
+      expect(apiService.postedData, {
+        'reason': 'item_arrived_damaged',
+        'message': 'Damaged sleeve.',
+      });
+    });
+
+    test('omits a blank optional dispute message', () async {
+      final apiService = _FakeApiService(
+        (_) => Result.failure('Unexpected GET'),
+        postHandler: (_, __) => Result.success({}),
+      );
+
+      await OrdersRepository(apiService).submitOrderDispute(
+        'order-1',
+        reason: 'something_else',
+        message: '   ',
+      );
+
+      expect(apiService.postedData, {'reason': 'something_else'});
+    });
+
     test('enriches order metadata without replacing its purchase price', () async {
       final apiService = _FakeApiService((endpoint) {
         if (endpoint == ApiEndpoints.myOrders) {

--- a/test/orders_repository_test.dart
+++ b/test/orders_repository_test.dart
@@ -63,6 +63,7 @@ void main() {
         'currency': ' gbp ',
         'deliveryState': ' shipped ',
         'deliveryLabel': ' On the way ',
+        'imageUrl': ' https://example.com/order-image.jpg ',
       });
 
       expect(order, isNotNull);
@@ -74,6 +75,7 @@ void main() {
       expect(order.currency, 'GBP');
       expect(order.deliveryState, 'shipped');
       expect(order.deliveryLabel, 'On the way');
+      expect(order.imageUrl, 'https://example.com/order-image.jpg');
     });
 
     test('retains valid ISO currencies and uses GBP only as a fallback', () {
@@ -308,6 +310,7 @@ void main() {
                   id: 'order-1',
                   productId: 'deleted-product',
                   productName: 'Purchased item',
+                  imageUrl: 'https://example.com/order-image.jpg',
                 ),
               ],
             },
@@ -322,7 +325,7 @@ void main() {
       expect(result.isSuccess, isTrue);
       final order = result.value!.single;
       expect(order.productName, 'Purchased item');
-      expect(order.imageUrl, isEmpty);
+      expect(order.imageUrl, 'https://example.com/order-image.jpg');
       expect(order.charityLogoUrl, isEmpty);
       expect(order.itemPriceMinor, 400);
     });
@@ -489,6 +492,7 @@ Map<String, dynamic> _orderJson({
   dynamic currency = 'GBP',
   dynamic deliveryState = 'preparing',
   String deliveryLabel = 'Preparing',
+  String imageUrl = '',
   String? status,
 }) {
   return {
@@ -500,6 +504,7 @@ Map<String, dynamic> _orderJson({
     'currency': currency,
     'deliveryState': deliveryState,
     'deliveryLabel': deliveryLabel,
+    'imageUrl': imageUrl,
     'status': status,
   };
 }

--- a/test/orders_view_model_test.dart
+++ b/test/orders_view_model_test.dart
@@ -9,12 +9,41 @@ import 'package:flutter_test/flutter_test.dart';
 
 class _QueuedOrdersRepository implements IOrdersRepository {
   final List<Future<Result<List<OrderSummary>>>> responses;
+  final List<Future<Result<dynamic>>> confirmationResponses;
+  final List<Future<Result<dynamic>>> disputeResponses;
+  String? confirmedOrderId;
+  String? disputedOrderId;
+  String? disputeReason;
+  String? disputeMessage;
 
-  _QueuedOrdersRepository(this.responses);
+  _QueuedOrdersRepository(
+    this.responses, {
+    List<Future<Result<dynamic>>>? confirmationResponses,
+    List<Future<Result<dynamic>>>? disputeResponses,
+  })  : confirmationResponses = confirmationResponses ?? [],
+        disputeResponses = disputeResponses ?? [];
 
   @override
   Future<Result<List<OrderSummary>>> fetchOrders() {
     return responses.removeAt(0);
+  }
+
+  @override
+  Future<Result<dynamic>> confirmOrderReceived(String orderId) {
+    confirmedOrderId = orderId;
+    return confirmationResponses.removeAt(0);
+  }
+
+  @override
+  Future<Result<dynamic>> submitOrderDispute(
+    String orderId, {
+    required String reason,
+    String? message,
+  }) {
+    disputedOrderId = orderId;
+    disputeReason = reason;
+    disputeMessage = message;
+    return disputeResponses.removeAt(0);
   }
 }
 
@@ -173,6 +202,81 @@ void main() {
       expect(viewModel.status.type, StatusType.uninitialized);
       expect(viewModel.orders, isEmpty);
       expect(notifications, 1);
+    });
+
+    test('confirms an order and updates its delivery state', () async {
+      final repository = _QueuedOrdersRepository(
+        [Future.value(Result.success([_order('order-1')]))],
+        confirmationResponses: [Future.value(Result.success({}))],
+      );
+      final viewModel = OrdersViewModel(repository: repository);
+      await viewModel.loadOrders();
+
+      final result = await viewModel.confirmOrderReceived('order-1');
+
+      expect(result.isSuccess, isTrue);
+      expect(repository.confirmedOrderId, 'order-1');
+      expect(viewModel.orders.single.deliveryState, 'confirmed');
+      expect(viewModel.orders.single.deliveryLabel, 'Confirmed');
+    });
+
+    test('preserves an order state when confirmation fails', () async {
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository(
+          [Future.value(Result.success([_order('order-1')]))],
+          confirmationResponses: [
+            Future.value(Result.failure('Could not confirm this item')),
+          ],
+        ),
+      );
+      await viewModel.loadOrders();
+
+      final result = await viewModel.confirmOrderReceived('order-1');
+
+      expect(result.isSuccess, isFalse);
+      expect(viewModel.orders.single.deliveryState, 'preparing');
+    });
+
+    test('submits a dispute and updates its delivery state', () async {
+      final repository = _QueuedOrdersRepository(
+        [Future.value(Result.success([_order('order-1')]))],
+        disputeResponses: [Future.value(Result.success({}))],
+      );
+      final viewModel = OrdersViewModel(repository: repository);
+      await viewModel.loadOrders();
+
+      final result = await viewModel.submitOrderDispute(
+        'order-1',
+        reason: 'wrong_item',
+        message: 'I received something else.',
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(repository.disputedOrderId, 'order-1');
+      expect(repository.disputeReason, 'wrong_item');
+      expect(repository.disputeMessage, 'I received something else.');
+      expect(viewModel.orders.single.deliveryState, 'disputed');
+      expect(viewModel.orders.single.deliveryLabel, 'Disputed');
+    });
+
+    test('preserves an order state when dispute submission fails', () async {
+      final viewModel = OrdersViewModel(
+        repository: _QueuedOrdersRepository(
+          [Future.value(Result.success([_order('order-1')]))],
+          disputeResponses: [
+            Future.value(Result.failure('Could not submit the dispute')),
+          ],
+        ),
+      );
+      await viewModel.loadOrders();
+
+      final result = await viewModel.submitOrderDispute(
+        'order-1',
+        reason: 'item_arrived_damaged',
+      );
+
+      expect(result.isSuccess, isFalse);
+      expect(viewModel.orders.single.deliveryState, 'preparing');
     });
   });
 }

--- a/test/orders_widgets_test.dart
+++ b/test/orders_widgets_test.dart
@@ -13,9 +13,13 @@ import 'package:provider/provider.dart';
 
 class _QueuedOrdersRepository implements IOrdersRepository {
   final List<Result<List<OrderSummary>>> responses;
+  final Result<dynamic>? confirmationResult;
   int requestCount = 0;
 
-  _QueuedOrdersRepository(this.responses);
+  _QueuedOrdersRepository(
+    this.responses, {
+    this.confirmationResult,
+  });
 
   @override
   Future<Result<List<OrderSummary>>> fetchOrders() async {
@@ -25,7 +29,7 @@ class _QueuedOrdersRepository implements IOrdersRepository {
 
   @override
   Future<Result<dynamic>> confirmOrderReceived(String orderId) async {
-    return Result.failure('Not configured for this test');
+    return confirmationResult ?? Result.failure('Not configured for this test');
   }
 
   @override
@@ -370,6 +374,37 @@ void main() {
 
     expect(find.text('Raise dispute'), findsOneWidget);
     expect(find.text('Tell us what went wrong'), findsOneWidget);
+  });
+
+  testWidgets('confirmation removes an order from Awaiting confirmation', (
+    tester,
+  ) async {
+    final viewModel = OrdersViewModel(
+      repository: _QueuedOrdersRepository(
+        [
+          Result.success([
+            _order(
+              deliveryState: 'awaiting_confirmation',
+              deliveryLabel: 'Awaiting your confirmation',
+            ),
+          ]),
+        ],
+        confirmationResult: Result.success({}),
+      ),
+    );
+
+    await _pumpPage(tester, viewModel: viewModel);
+    await tester.pumpAndSettle();
+    expect(find.text(AppStrings.myOrdersAwaitingConfirmation), findsOneWidget);
+
+    await tester.tap(find.text('Example shirt'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Yes, all good'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(AppStrings.myOrdersAwaitingConfirmation), findsNothing);
+    expect(find.text(AppStrings.myOrdersOther), findsOneWidget);
+    expect(find.text(AppStrings.myOrdersConfirmed), findsOneWidget);
   });
 
   testWidgets('disposing My Orders clears cached account data', (

--- a/test/orders_widgets_test.dart
+++ b/test/orders_widgets_test.dart
@@ -14,11 +14,15 @@ import 'package:provider/provider.dart';
 class _QueuedOrdersRepository implements IOrdersRepository {
   final List<Result<List<OrderSummary>>> responses;
   final Result<dynamic>? confirmationResult;
+  final Result<dynamic>? disputeResult;
+  String? disputeReason;
+  String? disputeMessage;
   int requestCount = 0;
 
   _QueuedOrdersRepository(
     this.responses, {
     this.confirmationResult,
+    this.disputeResult,
   });
 
   @override
@@ -38,7 +42,9 @@ class _QueuedOrdersRepository implements IOrdersRepository {
     required String reason,
     String? message,
   }) async {
-    return Result.failure('Not configured for this test');
+    disputeReason = reason;
+    disputeMessage = message;
+    return disputeResult ?? Result.failure('Not configured for this test');
   }
 }
 
@@ -139,6 +145,25 @@ void main() {
         AppStrings.myOrdersStatusUnavailable,
       );
     });
+  });
+
+  testWidgets('ConfirmItemDialog shows item details and omits a missing image', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ConfirmItemDialog(order: _order(imageUrl: '')),
+        ),
+      ),
+    );
+
+    expect(find.text('Confirm this item'), findsOneWidget);
+    expect(find.text('Example shirt'), findsOneWidget);
+    expect(find.text('Have you received your item as expected?'), findsOneWidget);
+    expect(find.text('Yes, all good'), findsOneWidget);
+    expect(find.text('Raise dispute'), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
   });
 
   testWidgets('ConfirmItemDialog returns its selected action', (tester) async {
@@ -405,6 +430,48 @@ void main() {
     expect(find.text(AppStrings.myOrdersAwaitingConfirmation), findsNothing);
     expect(find.text(AppStrings.myOrdersOther), findsOneWidget);
     expect(find.text(AppStrings.myOrdersConfirmed), findsOneWidget);
+    expect(find.text('Receipt confirmed'), findsOneWidget);
+  });
+
+  testWidgets('failed confirmation shows an error snackbar', (tester) async {
+    final viewModel = OrdersViewModel(
+      repository: _QueuedOrdersRepository(
+        [Result.success([_order(deliveryState: 'awaiting_confirmation')])],
+        confirmationResult: Result.failure('Confirmation unavailable'),
+      ),
+    );
+
+    await _pumpPage(tester, viewModel: viewModel);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Example shirt'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Yes, all good'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Confirmation unavailable'), findsOneWidget);
+  });
+
+  testWidgets('submitting a dispute sends its reason and message', (tester) async {
+    final repository = _QueuedOrdersRepository(
+      [Result.success([_order(deliveryState: 'awaiting_confirmation')])],
+      disputeResult: Result.success({}),
+    );
+    final viewModel = OrdersViewModel(repository: repository);
+
+    await _pumpPage(tester, viewModel: viewModel);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Example shirt'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Raise dispute'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'Wrong size received');
+    await tester.tap(find.text('Submit'));
+    await tester.pumpAndSettle();
+
+    expect(repository.disputeReason, 'wrong_item');
+    expect(repository.disputeMessage, 'Wrong size received');
+    expect(find.text('Dispute submitted'), findsOneWidget);
+    expect(find.text(AppStrings.myOrdersDisputed), findsOneWidget);
   });
 
   testWidgets('disposing My Orders clears cached account data', (

--- a/test/orders_widgets_test.dart
+++ b/test/orders_widgets_test.dart
@@ -21,6 +21,20 @@ class _QueuedOrdersRepository implements IOrdersRepository {
     requestCount++;
     return responses.removeAt(0);
   }
+
+  @override
+  Future<Result<dynamic>> confirmOrderReceived(String orderId) async {
+    return Result.failure('Not configured for this test');
+  }
+
+  @override
+  Future<Result<dynamic>> submitOrderDispute(
+    String orderId, {
+    required String reason,
+    String? message,
+  }) async {
+    return Result.failure('Not configured for this test');
+  }
 }
 
 OrderSummary _order({
@@ -298,6 +312,34 @@ void main() {
 
     expect(find.text('Example shirt'), findsOneWidget);
     expect(repository.requestCount, 2);
+  });
+
+  testWidgets('Raise dispute opens the dispute dialog from item confirmation', (
+    tester,
+  ) async {
+    final viewModel = OrdersViewModel(
+      repository: _QueuedOrdersRepository([
+        Result.success([
+          _order(
+            deliveryState: 'awaiting_confirmation',
+            deliveryLabel: 'Awaiting your confirmation',
+          ),
+        ]),
+      ]),
+    );
+
+    await _pumpPage(tester, viewModel: viewModel);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Example shirt'));
+    await tester.pumpAndSettle();
+    expect(find.text('Confirm this item'), findsOneWidget);
+
+    await tester.tap(find.text('Raise dispute'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Raise dispute'), findsOneWidget);
+    expect(find.text('Tell us what went wrong'), findsOneWidget);
   });
 
   testWidgets('disposing My Orders clears cached account data', (

--- a/test/orders_widgets_test.dart
+++ b/test/orders_widgets_test.dart
@@ -5,6 +5,7 @@ import 'package:cherry_mvp/features/orders/order_currency_formatter.dart';
 import 'package:cherry_mvp/features/orders/orders_page.dart';
 import 'package:cherry_mvp/features/orders/orders_repository.dart';
 import 'package:cherry_mvp/features/orders/orders_view_model.dart';
+import 'package:cherry_mvp/features/orders/widgets/confirm_item_dialog.dart';
 import 'package:cherry_mvp/features/orders/widgets/order_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -134,6 +135,35 @@ void main() {
         AppStrings.myOrdersStatusUnavailable,
       );
     });
+  });
+
+  testWidgets('ConfirmItemDialog returns its selected action', (tester) async {
+    ConfirmItemAction? selectedAction;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () async {
+                selectedAction = await showDialog<ConfirmItemAction>(
+                  context: context,
+                  builder: (_) => ConfirmItemDialog(order: _order()),
+                );
+              },
+              child: const Text('Open confirmation'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open confirmation'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Raise dispute'));
+    await tester.pumpAndSettle();
+
+    expect(selectedAction, ConfirmItemAction.dispute);
   });
 
   testWidgets('order card matches the required information hierarchy', (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added order sections for awaiting confirmation and other orders.
  - Users can open an order to confirm receipt or submit a dispute with a reason and optional message.
  - Added statuses for awaiting confirmation, confirmed, and disputed orders.
  - Order cards now support tapping, and available order images are displayed.

- **Bug Fixes**
  - Preserved order status and feedback when confirmation or dispute requests fail.

- **Tests**
  - Added coverage for confirmation, disputes, dialogs, status updates, and order images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->