### PR TITLE
Harden donation listing submission and add reliability coverage

### DIFF
--- a/docs/qa/listing-submission-reliability.md
+++ b/docs/qa/listing-submission-reliability.md
@@ -1,0 +1,51 @@
+# Listing submission reliability
+
+This frontend state-management and navigation change gives each accepted listing submission one completion owner. It preserves the request fields, validation, pricing, repository, upload service and backend behaviour.
+
+The work starts from main at `b72fca0`, on `cherry/reliable-listing-submission`. PR #489 was checked on 8 September 2026 and remained open. Its checkout changes are not included.
+
+Previously, submission and postage requests shared one status. Postage notifications could change the submission spinner, overlapping calls could reach the repository, and both a build callback and the Submit callback handled completion. Forms also accepted asynchronous selector and picker results after disposal.
+
+| File | Responsibility after the change |
+| --- | --- |
+| `lib/features/donation/donation_view_model.dart` | Owns independent `submissionStatus` and `postageStatus`, plus an independent submission lock. Returns `null` to ignored overlapping callers and a request-specific result to the accepted caller. Copies both image lists before notifying listeners. Releases the lock in `finally`. |
+| `lib/features/donation/widgets/donation_form.dart` | The awaited Submit handler alone handles UI completion. Captures submission values and rejects stale selector results. Successful current forms are replaced by the existing success route. Failed forms retain their draft and permit deliberate retry. |
+| `lib/features/donation/donation_page.dart` | Owns selected photos, disables Close, and registers a route pop guard that updates synchronously when submission starts. This blocks normal Back even before the next rebuild. |
+| `lib/features/donation/postage_size_page.dart` | Uses only postage state for loading, errors, retry and selection. |
+| `lib/features/donation/widgets/donation_form_field.dart`, `donation_dropdown_field.dart` | Allow form controls to be disabled while submitting. |
+| `lib/features/donation/widgets/photo_upload.dart` | Preserves photo state, copies lists across widget boundaries, disables photo controls and ignores obsolete picker results. Checks lifecycle before callbacks and page animations. |
+| `lib/features/donation/widgets/photo_tips_bar.dart` | Prevents the tips dialog from covering an active submission. |
+| `lib/core/services/safe_log.dart` | Adds a typed donor-discount persistence failure event without payloads or raw exceptions. |
+
+The application-scoped view model remains the submission boundary. Closing or disposing a form never resets that lock and does not cancel the upload or backend request. No form reads stored success as a navigation event, so reopening cannot replay an earlier completion.
+
+The initiating form keeps its own completion guard until failure or route replacement. Give and Liked Items use fullscreen dialog routes; Profile uses the named donations route. All three replace their exact form route on success, disposing both the form and its photos. Back from success cannot reveal the submitted draft.
+
+Forced navigation is handled separately from normal Close and Back. A disposed or already popped form performs no UI completion. If a newer route covers a still-active form, success removes only the old form beneath it, without opening success over the newer page. Failure leaves the original draft editable and suppresses the obsolete toast. The newer route remains current in both cases.
+
+Failure preserves title, description, price, category, charity, quality, size, postage and photos. No automatic retry is introduced. The caller chooses when to try again. Accepted image lists are immutable copies, while the retained draft remains editable after failure.
+
+Donor-discount persistence still runs only when `FeatureFlags.showDonorDiscounts` is enabled. Its captured value is passed to the accepted operation, which holds the lock until this local follow-up finishes. A persistence exception logs a typed warning and leaves listing creation successful. The flag remains false in the application.
+
+Verification uses `ControlledDonationRepository` and `Completer` responses. There are no real listing creations or uploads. Tests exercise the real Home/Give, Profile and Liked Items controls and Navigator stacks. Category and charity selection futures are controlled in the fixture; postage-page routes are also exercised directly. Photo-picker results use a mocked method channel and local image fixtures.
+
+| Automated coverage | Test file |
+| --- | --- |
+| Overlap rejection; postage success, failure and exceptions during submission; failure and exception retry; immutable image snapshots; disposed view-model completion; donor-discount persistence and its failure | `test/donation_view_model_test.dart` |
+| Rapid taps before rebuild; one success replacement across all three entry points; full draft preservation and retry; immediate Close/Back/tips guards; forced disposal, exit animations, covering routes and reopening; late category, charity, postage and gallery results; unchanged invalid-form checks; postage loading, retry, initial choice, selection and empty state | `test/donation_submission_widgets_test.dart` |
+| Existing postage-ID request serialisation contract | `test/donation_model_test.dart` |
+
+The verified SDK is Flutter 3.44.4 with Dart 3.12.2 at `/Users/bradleyvenn/Documents/cherry/flutter`. Dependencies were resolved with `flutter pub get --enforce-lockfile`; `pubspec.lock` did not change. Main's baseline passed 158 tests and had no analyser issues. An empty, temporary `.env` asset was used for tests and removed afterwards.
+
+Final checks:
+
+- Targeted donation tests: 34 passed, including 33 new regression cases and the existing model test.
+- `flutter test --no-pub`: 191 passed.
+- `flutter analyze --no-pub`: no issues found.
+- `bash tool/check_safe_logging.sh`: passed.
+- `git diff --check`: passed.
+- Changed Dart files formatted; a second format check made no changes.
+
+This prevents overlapping submissions through the shared frontend view model. It does not guarantee exactly-once creation across an ambiguous network response, process termination, another app instance or multiple devices. A deliberate retry after an ambiguous failure can still create a duplicate. Server-side idempotency remains outside this change.
+
+Native Android/iOS camera and gallery permission flows, native image conversion, predictive-back gestures on a device, real uploads, backend behaviour and the enabled donor-discount UI have not been exercised. The gallery callback lifecycle and donor-discount persistence branch are covered with fakes. A hung request continues to hold the lock until its existing repository/network behaviour completes; no cancellation or new timeout policy is introduced.

--- a/lib/core/services/safe_log.dart
+++ b/lib/core/services/safe_log.dart
@@ -27,6 +27,7 @@ enum AppLogEvent {
   checkoutProfileLoadFailed,
   checkoutProfileMissing,
   checkoutShippingMethodsFailed,
+  donationDiscountPersistenceFailed,
   donationImageUploadFailed,
   donationImageUploadStarted,
   donationImageUploadSucceeded,

--- a/lib/features/donation/donation_page.dart
+++ b/lib/features/donation/donation_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:cherry_mvp/core/config/app_strings.dart';
 import 'package:cherry_mvp/features/donation/widgets/photo_tips_bar.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+import 'donation_view_model.dart';
 import 'widgets/donation_form.dart';
 
 class DonationPage extends StatefulWidget {
@@ -14,26 +16,65 @@ class DonationPage extends StatefulWidget {
 
 class _DonationPageState extends State<DonationPage> {
   List<XFile> selectedImages = [];
-  final GlobalKey<DonationFormState> _formKey = GlobalKey<DonationFormState>();
+  final _popEntry = _SubmissionPopEntry();
+  DonationViewModel? _viewModel;
+  ModalRoute<dynamic>? _route;
 
-  void _handleImagesChanged(List<XFile> images) {
-    setState(() {
-      selectedImages = images;
-    });
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final viewModel = context.read<DonationViewModel>();
+    if (_viewModel != viewModel) {
+      _viewModel?.removeListener(_updatePopPermission);
+      _viewModel = viewModel;
+      _viewModel!.addListener(_updatePopPermission);
+      _updatePopPermission();
+    }
+    final route = ModalRoute.of(context);
+    if (_route != route) {
+      _route?.unregisterPopEntry(_popEntry);
+      _route = route;
+      _route?.registerPopEntry(_popEntry);
+    }
   }
 
-  void _clearImages() {
+  void _updatePopPermission() {
+    // Block Back immediately, including before the submission's first rebuild.
+    _popEntry.canPopNotifier.value = !_viewModel!.isSubmitting;
+  }
+
+  @override
+  void dispose() {
+    _viewModel?.removeListener(_updatePopPermission);
+    _route?.unregisterPopEntry(_popEntry);
+    _popEntry.canPopNotifier.dispose();
+    super.dispose();
+  }
+
+  void _handleImagesChanged(List<XFile> images) {
+    if (!mounted || context.read<DonationViewModel>().isSubmitting) return;
     setState(() {
-      selectedImages = [];
+      selectedImages = List.of(images);
     });
   }
 
   @override
   Widget build(BuildContext context) {
+    final isSubmitting = context.watch<DonationViewModel>().isSubmitting;
     return Scaffold(
       appBar: AppBar(
         centerTitle: true,
-        leading: const CloseButton(),
+        leading: IconButton(
+          tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+          icon: const Icon(Icons.close),
+          onPressed: isSubmitting
+              ? null
+              : () {
+                  if (!context.read<DonationViewModel>().isSubmitting) {
+                    Navigator.of(context).maybePop();
+                  }
+                },
+        ),
         title: const Text(
           AppStrings.donationsText,
           style: TextStyle(fontWeight: FontWeight.bold),
@@ -44,17 +85,22 @@ class _DonationPageState extends State<DonationPage> {
           children: [
             PhotoUpload(
               onImagesChanged: _handleImagesChanged,
+              initialImages: selectedImages,
+              enabled: !isSubmitting,
             ),
             const PhotoTipsBar(),
             const SizedBox(height: 16),
             DonationForm(
-              key: _formKey,
               selectedImages: selectedImages,
-              onClearImages: _clearImages,
             ),
           ],
         ),
       ),
     );
   }
+}
+
+class _SubmissionPopEntry extends PopEntry<Object?> {
+  @override
+  final ValueNotifier<bool> canPopNotifier = ValueNotifier<bool>(true);
 }

--- a/lib/features/donation/donation_view_model.dart
+++ b/lib/features/donation/donation_view_model.dart
@@ -6,6 +6,7 @@ import 'package:cherry_mvp/core/router/nav_provider.dart';
 import 'package:cherry_mvp/core/router/nav_routes.dart';
 import 'package:cherry_mvp/core/services/safe_log.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
+import 'package:cherry_mvp/core/utils/donor_discount_state_store.dart';
 import 'package:cherry_mvp/features/charity_page/charity_model.dart';
 import 'package:cherry_mvp/features/donation/donation_repository.dart';
 import 'package:cherry_mvp/features/donation/models/donation_model.dart';
@@ -17,62 +18,77 @@ class DonationViewModel extends ChangeNotifier {
 
   DonationViewModel({required this._donationRepository, required this.navigator});
 
-  Status _status = Status.uninitialized;
-  DonationResponse? _lastSubmission;
-  String? _submissionMessage;
+  Status _submissionStatus = Status.uninitialized;
+  Status _postageStatus = Status.uninitialized;
+  bool _submissionInFlight = false;
+  bool _disposed = false;
 
-  Status get status => _status;
-  DonationResponse? get lastSubmission => _lastSubmission;
-  String? get submissionMessage => _submissionMessage;
+  Status get submissionStatus => _submissionStatus;
+  Status get postageStatus => _postageStatus;
+  bool get isSubmitting => _submissionInFlight;
 
   List<PostageSizeInfo> _postageSizeInfos = [];
   List<PostageSizeInfo> get postageSizeInfos => _postageSizeInfos;
 
-  Future<void> submitDonation(DonationRequest request) async {
+  /// Null means this call was ignored. Only the accepted caller owns its result.
+  /// Disposing a form or loading postage never releases the submission lock.
+  Future<Result<DonationResponse>?> submitDonation(
+    DonationRequest request, {
+    bool? donorDiscountActive,
+  }) async {
+    if (_submissionInFlight || _disposed) return null;
+    _submissionInFlight = true;
+    _submissionStatus = Status.loading;
     SafeLog.event(AppLogEvent.donationSubmissionStarted);
-
-    _status = Status.loading;
-    _submissionMessage = null;
-    _lastSubmission = null;
-    notifyListeners();
-
     try {
-      final result = await _donationRepository.submitDonation(request);
+      final submittedRequest = request.copyWith(
+        localImages: request.localImages == null ? null : List.unmodifiable(request.localImages!),
+        productImages: request.productImages == null ? null : List.unmodifiable(request.productImages!),
+      );
+      notifyListeners();
+      final result = await _donationRepository.submitDonation(submittedRequest);
 
-      if (result.isSuccess) {
-        _status = Status.success;
-        _lastSubmission = result.value!;
-        _submissionMessage = AppStrings.donationSubmittedSuccessfully;
+      if (result.isSuccess && result.value != null) {
+        // The listing already exists. Local follow-up failure must not invite a retry.
+        if (donorDiscountActive != null) {
+          try {
+            await DonorDiscountStateStore.setDonorDiscountState(result.value!.id, donorDiscountActive);
+          } catch (_) {
+            SafeLog.event(
+              AppLogEvent.donationDiscountPersistenceFailed,
+              level: SafeLogLevel.warning,
+            );
+          }
+        }
+        _submissionStatus = Status.success;
         SafeLog.event(AppLogEvent.donationSubmissionSucceeded);
-      } else {
-        _status = Status.failure(result.error ?? "Unknown error");
-        _submissionMessage = result.error ?? "Failed to submit donation";
-        SafeLog.event(
-          AppLogEvent.donationSubmissionFailed,
-          level: SafeLogLevel.warning,
-        );
+        return result;
       }
-    } catch (e) {
-      _status = Status.failure(AppStrings.unexpectedErrorOccurred);
-      _submissionMessage = AppStrings.unexpectedErrorOccurred;
+
+      final message = result.error ?? AppStrings.failedToSubmitDonation;
+      _submissionStatus = Status.failure(message);
+      SafeLog.event(
+        AppLogEvent.donationSubmissionFailed,
+        level: SafeLogLevel.warning,
+      );
+      return Result.failure(message);
+    } catch (_) {
+      _submissionStatus = Status.failure(AppStrings.unexpectedErrorOccurred);
       SafeLog.event(
         AppLogEvent.donationSubmissionFailed,
         level: SafeLogLevel.severe,
       );
+      return Result.failure(AppStrings.unexpectedErrorOccurred);
+    } finally {
+      _submissionInFlight = false;
+      if (!_disposed) notifyListeners();
     }
-
-    notifyListeners();
   }
 
-  void resetStatus() {
-    _status = Status.uninitialized;
-    _submissionMessage = null;
-    _lastSubmission = null;
-    notifyListeners();
-  }
-
-  Future<void> showDonationSuccess() async {
-    navigator.navigateTo(AppRoutes.donationSuccess);
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
   }
 
   void selectType([ImageSource? imgSource]) {
@@ -111,7 +127,8 @@ class DonationViewModel extends ChangeNotifier {
   }
 
   Future<void> fetchPostageSizes() async {
-    _status = Status.loading;
+    if (_disposed || _postageStatus.type == StatusType.loading) return;
+    _postageStatus = Status.loading;
     notifyListeners();
 
     try {
@@ -119,23 +136,23 @@ class DonationViewModel extends ChangeNotifier {
 
       if (result.isSuccess && result.value != null) {
         _postageSizeInfos = result.value!;
-        _status = Status.success;
+        _postageStatus = Status.success;
       } else {
-        _status = Status.failure(result.error ?? 'Failed to fetch postage sizes');
+        _postageStatus = Status.failure(result.error ?? 'Failed to fetch postage sizes');
         SafeLog.event(
           AppLogEvent.donationPostageSizesLoadFailed,
           level: SafeLogLevel.warning,
         );
       }
     } catch (e) {
-      _status = Status.failure(e.toString());
+      _postageStatus = Status.failure(AppStrings.postageSizeInfoError);
       SafeLog.event(
         AppLogEvent.donationPostageSizesLoadFailed,
         level: SafeLogLevel.severe,
       );
     }
 
-    notifyListeners();
+    if (!_disposed) notifyListeners();
   }
 
   void goBack([PostageSizeInfo? postageSize]) {

--- a/lib/features/donation/postage_size_page.dart
+++ b/lib/features/donation/postage_size_page.dart
@@ -38,7 +38,7 @@ class PostageSizePageState extends State<PostageSizePage> {
     return Consumer<DonationViewModel>(
       builder: (context, viewModel, child) {
         final postageSizeInfos = viewModel.postageSizeInfos;
-        final status = viewModel.status;
+        final status = viewModel.postageStatus;
 
         return Scaffold(
           appBar: AppBar(

--- a/lib/features/donation/widgets/donation_dropdown_field.dart
+++ b/lib/features/donation/widgets/donation_dropdown_field.dart
@@ -7,12 +7,14 @@ class DonationDropdownField extends StatefulWidget {
     required this.dropdownList,
     required this.onChanged,
     this.selectedValue,
+    this.enabled = true,
   });
 
   final String formFieldsHintText;
   final List<String> dropdownList;
   final ValueChanged<String?> onChanged;
   final String? selectedValue;
+  final bool enabled;
 
   @override
   DonationDropdownFieldState createState() => DonationDropdownFieldState();
@@ -32,6 +34,7 @@ class DonationDropdownFieldState extends State<DonationDropdownField> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: DropdownMenuFormField<String>(
+        enabled: widget.enabled,
         width: double.infinity,
         label: Text(widget.formFieldsHintText),
         hintText: widget.formFieldsHintText,

--- a/lib/features/donation/widgets/donation_form.dart
+++ b/lib/features/donation/widgets/donation_form.dart
@@ -6,7 +6,6 @@ import 'package:provider/provider.dart';
 import 'package:cherry_mvp/core/config/app_colors.dart';
 import 'package:cherry_mvp/core/config/feature_flags.dart';
 import 'package:cherry_mvp/core/config/app_strings.dart';
-import 'package:cherry_mvp/core/utils/donor_discount_state_store.dart';
 import 'package:cherry_mvp/core/utils/utils.dart';
 import 'package:cherry_mvp/core/models/category.dart';
 import 'package:cherry_mvp/core/router/router.dart';
@@ -23,9 +22,8 @@ import 'package:cherry_mvp/features/donation/widgets/donation_dropdown_field.dar
 
 class DonationForm extends StatefulWidget {
   final List<XFile>? selectedImages;
-  final VoidCallback? onClearImages;
 
-  const DonationForm({super.key, this.selectedImages, this.onClearImages});
+  const DonationForm({super.key, this.selectedImages});
 
   @override
   DonationFormState createState() => DonationFormState();
@@ -51,6 +49,10 @@ class DonationFormState extends State<DonationForm> {
 
   Charity? selectedCharity;
   bool _hasInitialized = false;
+  bool _handlingSubmission = false;
+  int _draftGeneration = 0;
+
+  bool get _canEdit => mounted && !_handlingSubmission && !context.read<DonationViewModel>().isSubmitting;
   final _hideUnimplementedFeatures = true;
 
   @override
@@ -59,6 +61,7 @@ class DonationFormState extends State<DonationForm> {
     if (!_hasInitialized) {
       _hasInitialized = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
         context.read<CharityViewModel>().fetchCharities();
         context.read<CategoryViewModel>().fetchCategories();
       });
@@ -66,14 +69,17 @@ class DonationFormState extends State<DonationForm> {
   }
 
   void toggleSwitchOpenToOtherCharity(bool value) {
+    if (!_canEdit) return;
     setState(() => isSwitchedOpenToOtherCharity = value);
   }
 
   void toggleSwitchOpenToOffer(bool value) {
+    if (!_canEdit) return;
     setState(() => isSwitchedOpenToOffer = value);
   }
 
   void toggleSwitchApplicableBuyerDiscounts(bool value) {
+    if (!_canEdit) return;
     setState(() => isSwitchedApplicableBuyerDiscounts = value);
   }
 
@@ -103,24 +109,77 @@ class DonationFormState extends State<DonationForm> {
     );
   }
 
-  void _clearForm() {
-    _titleController.clear();
-    _descriptionController.clear();
-    _addToCollectionController.clear();
-    _priceController.clear();
-    setState(() {
-      selectedCategory = '';
-      selectedCategoryId = '';
-      selectedCondition = '';
-      selectedQuality = '';
-      selectedSize = '';
-      selectedPostageSize = null;
-      selectedCharity = null;
-      isSwitchedOpenToOtherCharity = false;
-      isSwitchedOpenToOffer = false;
-      isSwitchedApplicableBuyerDiscounts = false;
-    });
-    widget.onClearImages?.call();
+  Future<void> _submitDonation() async {
+    if (!_canEdit) return;
+    if (_formKey.currentState!.validate()) {
+      final priceText = _priceController.text.trim();
+
+      // Validate required dropdowns
+      if (priceText.isEmpty || selectedQuality.isEmpty || selectedSize.isEmpty) {
+        Fluttertoast.showToast(
+          msg: AppStrings.pleaseSelectAllDropdowns,
+        );
+        return;
+      }
+      if (selectedCategoryId.trim().isEmpty) {
+        Fluttertoast.showToast(
+          msg: AppStrings.pleaseSelectCategory,
+        );
+        return;
+      }
+      if (selectedCharity == null) {
+        Fluttertoast.showToast(
+          msg: AppStrings.pleaseSelectCharity,
+        );
+        return;
+      }
+      if (selectedPostageSize == null) {
+        Fluttertoast.showToast(
+          msg: AppStrings.pleaseChoosePostageSize,
+        );
+        return;
+      }
+      if (widget.selectedImages == null || widget.selectedImages!.isEmpty) {
+        Fluttertoast.showToast(msg: AppStrings.pleaseAddPhoto);
+        return;
+      }
+      final donationViewModel = context.read<DonationViewModel>();
+      final route = ModalRoute.of(context);
+      if (route == null || !route.isCurrent) return;
+      final navigator = Navigator.of(context);
+      final request = _buildDonationRequest();
+      FocusScope.of(context).unfocus();
+      setState(() {
+        _handlingSubmission = true;
+        _draftGeneration++;
+      });
+      final result = await donationViewModel.submitDonation(
+        request,
+        donorDiscountActive: FeatureFlags.showDonorDiscounts ? isSwitchedApplicableBuyerDiscounts : null,
+      );
+      if (!mounted) return;
+      // A forced route change makes this completion obsolete, even during exit animation.
+      if (!route.isActive) return;
+      if (result != null && result.isSuccess) {
+        if (!route.isCurrent) {
+          // A newer route stays visible. Only discard this completed draft.
+          navigator.removeRoute(route);
+          return;
+        }
+        // Replace this exact form, whether it came from a dialog or a named route.
+        // Keep the form locked until replacement disposes its draft and photos.
+        navigator.pushReplacementNamed(AppRoutes.donationSuccess);
+        return;
+      }
+      setState(() => _handlingSubmission = false);
+      if (route.isCurrent && result != null) {
+        Fluttertoast.showToast(
+          msg: result.error ?? AppStrings.unexpectedErrorOccurred,
+          backgroundColor: Colors.red,
+          textColor: Colors.white,
+        );
+      }
+    }
   }
 
   @override
@@ -136,45 +195,22 @@ class DonationFormState extends State<DonationForm> {
   Widget build(BuildContext context) {
     return Consumer<DonationViewModel>(
       builder: (context, donationViewModel, child) {
-        WidgetsBinding.instance.addPostFrameCallback((_) async {
-          if (donationViewModel.status.type == StatusType.success && donationViewModel.lastSubmission != null) {
-            final navigator = Navigator.of(context);
-            final navigationProvider = Provider.of<NavigationProvider>(
-              context,
-              listen: false,
-            );
-            if (FeatureFlags.showDonorDiscounts) {
-              await DonorDiscountStateStore.setDonorDiscountState(
-                donationViewModel.lastSubmission!.id,
-                isSwitchedApplicableBuyerDiscounts,
-              );
-            }
-            if (!mounted) return;
-            _clearForm();
-            donationViewModel.resetStatus();
-            navigator.pop();
-            navigationProvider.navigateTo(AppRoutes.donationSuccess);
-          } else if (donationViewModel.status.type == StatusType.failure) {
-            final errorMessage = donationViewModel.submissionMessage ?? AppStrings.unexpectedErrorOccurred;
-            Fluttertoast.showToast(
-              msg: errorMessage,
-              backgroundColor: Colors.red,
-              textColor: Colors.white,
-            );
-          }
-        });
+        final busy = _handlingSubmission || donationViewModel.isSubmitting;
 
         return Form(
           key: _formKey,
+          canPop: !busy,
           child: Column(
             children: [
               DonationFormField(
+                enabled: !busy,
                 controller: _titleController,
                 hintText: titleHintText,
                 title: AppStrings.titleText,
                 hintIcon: Icons.add_circle_outline,
               ),
               DonationFormField(
+                enabled: !busy,
                 controller: _descriptionController,
                 hintText: descriptionHintText,
                 title: AppStrings.descriptionText,
@@ -221,24 +257,33 @@ class DonationFormState extends State<DonationForm> {
                     );
                   } else if (categories.isEmpty) {
                     return DonationDropdownField(
+                      enabled: !busy,
                       formFieldsHintText: categoryHintText,
                       dropdownList: categoryDropdownList,
-                      onChanged: (val) => setState(() => selectedCategory = val!),
+                      onChanged: (val) {
+                        if (_canEdit) setState(() => selectedCategory = val!);
+                      },
                     );
                   } else {
                     return _SelectionField(
                       label: categoryHintText,
                       value: selectedCategory.isNotEmpty ? selectedCategory : null,
-                      onTap: () async {
-                        final Category? result = await donationViewModel.navigateToCategoryPage(selectedCategoryId);
+                      onTap: busy
+                          ? null
+                          : () async {
+                              if (!_canEdit) return;
+                              final generation = _draftGeneration;
+                              final Category? result = await donationViewModel.navigateToCategoryPage(
+                                selectedCategoryId,
+                              );
 
-                        if (result != null) {
-                          setState(() {
-                            selectedCategory = result.name;
-                            selectedCategoryId = result.id;
-                          });
-                        }
-                      },
+                              if (_canEdit && generation == _draftGeneration && result != null) {
+                                setState(() {
+                                  selectedCategory = result.name;
+                                  selectedCategoryId = result.id;
+                                });
+                              }
+                            },
                     );
                   }
                 },
@@ -290,13 +335,19 @@ class DonationFormState extends State<DonationForm> {
                     return _SelectionField(
                       label: AppStrings.charityText,
                       value: selectedCharity?.name,
-                      onTap: () async {
-                        final Charity? result = await donationViewModel.navigateToCharityPage(selectedCharity?.id);
+                      onTap: busy
+                          ? null
+                          : () async {
+                              if (!_canEdit) return;
+                              final generation = _draftGeneration;
+                              final Charity? result = await donationViewModel.navigateToCharityPage(
+                                selectedCharity?.id,
+                              );
 
-                        if (result != null) {
-                          setState(() => selectedCharity = result);
-                        }
-                      },
+                              if (_canEdit && generation == _draftGeneration && result != null) {
+                                setState(() => selectedCharity = result);
+                              }
+                            },
                     );
                   }
                 },
@@ -308,6 +359,7 @@ class DonationFormState extends State<DonationForm> {
                   vertical: 8.0,
                 ),
                 child: TextFormField(
+                  enabled: !busy,
                   controller: _priceController,
                   decoration: InputDecoration(
                     labelText: AppStrings.priceText,
@@ -343,34 +395,45 @@ class DonationFormState extends State<DonationForm> {
                 ),
               ),
               DonationDropdownField(
+                enabled: !busy,
                 formFieldsHintText: qualityHintText,
                 dropdownList: qualityDropdownList,
-                onChanged: (val) => setState(() => selectedQuality = val!),
+                onChanged: (val) {
+                  if (_canEdit) setState(() => selectedQuality = val!);
+                },
                 selectedValue: selectedQuality.isNotEmpty ? selectedQuality : null,
               ),
 
               DonationDropdownField(
+                enabled: !busy,
                 formFieldsHintText: sizeHintText,
                 dropdownList: sizeDropdownList,
-                onChanged: (val) => setState(() => selectedSize = val!),
+                onChanged: (val) {
+                  if (_canEdit) setState(() => selectedSize = val!);
+                },
                 selectedValue: selectedSize.isNotEmpty ? selectedSize : null,
               ),
 
               _SelectionField(
                 label: postageSizeHintText,
                 value: selectedPostageSize?.size.label,
-                onTap: () async {
-                  final PostageSizeInfo? result = await donationViewModel.navigateToPostageSizePage(
-                    selectedPostageSize,
-                  );
+                onTap: busy
+                    ? null
+                    : () async {
+                        if (!_canEdit) return;
+                        final generation = _draftGeneration;
+                        final PostageSizeInfo? result = await donationViewModel.navigateToPostageSizePage(
+                          selectedPostageSize,
+                        );
 
-                  if (result != null) {
-                    setState(() => selectedPostageSize = result);
-                  }
-                },
+                        if (_canEdit && generation == _draftGeneration && result != null) {
+                          setState(() => selectedPostageSize = result);
+                        }
+                      },
               ),
               if (!_hideUnimplementedFeatures) ...[
                 DonationFormField(
+                  enabled: !busy,
                   controller: _addToCollectionController,
                   hintText: addToCollectionHintText,
                   title: addToCollectionText,
@@ -423,64 +486,13 @@ class DonationFormState extends State<DonationForm> {
 
               Padding(
                 padding: const EdgeInsets.all(16),
-                child: donationViewModel.status.type == StatusType.loading
+                child: busy
                     ? const Center(child: CircularProgressIndicator())
                     : SizedBox(
                         height: 56,
                         width: double.infinity,
                         child: FilledButton(
-                          onPressed: () async {
-                            if (_formKey.currentState!.validate()) {
-                              final priceText = _priceController.text.trim();
-
-                              // Validate required dropdowns
-                              if (priceText.isEmpty || selectedQuality.isEmpty || selectedSize.isEmpty) {
-                                Fluttertoast.showToast(
-                                  msg: AppStrings.pleaseSelectAllDropdowns,
-                                );
-                                return;
-                              }
-                              if (selectedCategoryId.trim().isEmpty) {
-                                Fluttertoast.showToast(
-                                  msg: AppStrings.pleaseSelectCategory,
-                                );
-                                return;
-                              }
-                              if (selectedCharity == null) {
-                                Fluttertoast.showToast(
-                                  msg: AppStrings.pleaseSelectCharity,
-                                );
-                                return;
-                              }
-                              if (selectedPostageSize == null) {
-                                Fluttertoast.showToast(
-                                  msg: AppStrings.pleaseChoosePostageSize,
-                                );
-                                return;
-                              }
-                              if (widget.selectedImages == null || widget.selectedImages!.isEmpty) {
-                                Fluttertoast.showToast(msg: AppStrings.pleaseAddPhoto);
-                                return;
-                              }
-                              final request = _buildDonationRequest();
-                              await donationViewModel.submitDonation(request);
-
-                              if (donationViewModel.status.type == StatusType.success &&
-                                  donationViewModel.lastSubmission != null) {
-                                _clearForm();
-                                donationViewModel.resetStatus();
-                                donationViewModel.showDonationSuccess();
-                              } else if (donationViewModel.status.type == StatusType.failure) {
-                                final errorMessage =
-                                    donationViewModel.submissionMessage ?? AppStrings.unexpectedErrorOccurred;
-                                Fluttertoast.showToast(
-                                  msg: errorMessage,
-                                  backgroundColor: Colors.red,
-                                  textColor: Colors.white,
-                                );
-                              }
-                            }
-                          },
+                          onPressed: _submitDonation,
                           child: const Text(AppStrings.submitDonation),
                         ),
                       ),
@@ -502,7 +514,7 @@ class _SelectionField extends StatelessWidget {
 
   final String label;
   final String? value;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -518,6 +530,7 @@ class _SelectionField extends StatelessWidget {
         child: InputDecorator(
           decoration: InputDecoration(
             labelText: label,
+            enabled: onTap != null,
             suffixIcon: const Icon(Icons.chevron_right),
             border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
             enabledBorder: OutlineInputBorder(

--- a/lib/features/donation/widgets/donation_form_field.dart
+++ b/lib/features/donation/widgets/donation_form_field.dart
@@ -3,6 +3,7 @@ import 'package:cherry_mvp/core/utils/utils.dart';
 
 class DonationFormField extends StatelessWidget {
   final TextEditingController controller;
+  final bool enabled;
   final String hintText;
   final String? title;
   final IconData? hintIcon;
@@ -12,6 +13,7 @@ class DonationFormField extends StatelessWidget {
 
   const DonationFormField({
     super.key,
+    this.enabled = true,
     required this.controller,
     required this.hintText,
     this.hintIcon,
@@ -40,6 +42,7 @@ class DonationFormField extends StatelessWidget {
           Padding(
             padding: EdgeInsets.only(bottom: 10),
             child: TextFormField(
+              enabled: enabled,
               maxLines: null,
               controller: controller,
               minLines: minLines,

--- a/lib/features/donation/widgets/photo_tips_bar.dart
+++ b/lib/features/donation/widgets/photo_tips_bar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:cherry_mvp/core/config/app_strings.dart';
+import 'package:cherry_mvp/features/donation/donation_view_model.dart';
 import 'package:cherry_mvp/features/donation/widgets/photo_tips_dialog.dart';
 
 class PhotoTipsBar extends StatelessWidget {
@@ -7,6 +9,7 @@ class PhotoTipsBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isSubmitting = context.watch<DonationViewModel>().isSubmitting;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Material(
@@ -14,12 +17,15 @@ class PhotoTipsBar extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         child: InkWell(
           borderRadius: BorderRadius.circular(8),
-          onTap: () {
-            showDialog(
-              context: context,
-              builder: (context) => const PhotoTipsDialog(),
-            );
-          },
+          onTap: isSubmitting
+              ? null
+              : () {
+                  if (context.read<DonationViewModel>().isSubmitting) return;
+                  showDialog(
+                    context: context,
+                    builder: (context) => const PhotoTipsDialog(),
+                  );
+                },
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
             child: Row(

--- a/lib/features/donation/widgets/photo_upload.dart
+++ b/lib/features/donation/widgets/photo_upload.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
@@ -12,8 +13,9 @@ import 'package:cherry_mvp/features/donation/donation_view_model.dart';
 class PhotoUpload extends StatefulWidget {
   final Function(List<XFile>)? onImagesChanged;
   final List<XFile>? initialImages;
+  final bool enabled;
 
-  const PhotoUpload({super.key, this.onImagesChanged, this.initialImages});
+  const PhotoUpload({super.key, this.onImagesChanged, this.initialImages, this.enabled = true});
 
   @override
   State<PhotoUpload> createState() => _PhotoUploadState();
@@ -26,6 +28,9 @@ class _PhotoUploadState extends State<PhotoUpload> {
   List<XFile> selectedImages = [];
   final PageController _pageController = PageController();
   int _currentImageIndex = 0;
+  int _pickGeneration = 0;
+
+  bool get _canEdit => mounted && widget.enabled && !context.read<DonationViewModel>().isSubmitting;
 
   bool _shouldRetryWithoutTransforms(PlatformException error) {
     final message = (error.message ?? '').toLowerCase();
@@ -96,8 +101,9 @@ class _PhotoUploadState extends State<PhotoUpload> {
   @override
   void didUpdateWidget(PhotoUpload oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!widget.enabled && oldWidget.enabled) _pickGeneration++;
     // Update selected images if initialImages changed
-    if (widget.initialImages != oldWidget.initialImages) {
+    if (widget.initialImages != oldWidget.initialImages && !listEquals(widget.initialImages, selectedImages)) {
       if (widget.initialImages != null && widget.initialImages!.isNotEmpty) {
         setState(() {
           selectedImages = List.from(widget.initialImages!);
@@ -113,12 +119,15 @@ class _PhotoUploadState extends State<PhotoUpload> {
   }
 
   Future<void> pickImages(ImageSource source) async {
+    if (!_canEdit) return;
+    final generation = _pickGeneration;
     try {
       final picker = ImagePicker();
       if (source == ImageSource.gallery) {
         // Allow multiple selection from gallery
         final List<XFile> picked = await _pickGalleryImages(picker);
 
+        if (!_canEdit || generation != _pickGeneration) return;
         if (picked.isNotEmpty) {
           // Filter out duplicates based on file path
           final List<XFile> newImages = [];
@@ -136,12 +145,12 @@ class _PhotoUploadState extends State<PhotoUpload> {
               selectedImages.addAll(newImages);
               _currentImageIndex = selectedImages.length - 1;
             });
-            widget.onImagesChanged?.call(selectedImages);
+            widget.onImagesChanged?.call(List.of(selectedImages));
 
             // Animate to the last added image
             if (selectedImages.length > 1) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (_pageController.hasClients) {
+                if (mounted && _pageController.hasClients) {
                   _pageController.animateToPage(
                     _currentImageIndex,
                     duration: const Duration(milliseconds: 300),
@@ -156,6 +165,7 @@ class _PhotoUploadState extends State<PhotoUpload> {
         // Single image from camera
         final XFile? picked = await _pickCameraImage(picker);
 
+        if (!_canEdit || generation != _pickGeneration) return;
         if (picked != null) {
           // Check for duplicates
           final isDuplicate = selectedImages.any(
@@ -167,12 +177,12 @@ class _PhotoUploadState extends State<PhotoUpload> {
               selectedImages.add(picked);
               _currentImageIndex = selectedImages.length - 1;
             });
-            widget.onImagesChanged?.call(selectedImages);
+            widget.onImagesChanged?.call(List.of(selectedImages));
 
             // Animate to the newly added image
             if (selectedImages.length > 1) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (_pageController.hasClients) {
+                if (mounted && _pageController.hasClients) {
                   _pageController.animateToPage(
                     _currentImageIndex,
                     duration: const Duration(milliseconds: 300),
@@ -185,13 +195,13 @@ class _PhotoUploadState extends State<PhotoUpload> {
         }
       }
     } on PlatformException catch (error) {
-      if (mounted) {
+      if (mounted && _canEdit && generation == _pickGeneration) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(_platformImageErrorMessage(error))),
         );
       }
     } catch (e) {
-      if (mounted) {
+      if (mounted && _canEdit && generation == _pickGeneration) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('${AppStrings.errorPickingImage}: $e')),
         );
@@ -200,6 +210,7 @@ class _PhotoUploadState extends State<PhotoUpload> {
   }
 
   void _removeImage(int index) {
+    if (!_canEdit) return;
     setState(() {
       selectedImages.removeAt(index);
       if (_currentImageIndex >= selectedImages.length && selectedImages.isNotEmpty) {
@@ -208,12 +219,12 @@ class _PhotoUploadState extends State<PhotoUpload> {
         _currentImageIndex = 0;
       }
     });
-    widget.onImagesChanged?.call(selectedImages);
+    widget.onImagesChanged?.call(List.of(selectedImages));
 
     // Animate to valid page if needed
     if (selectedImages.isNotEmpty && _currentImageIndex < selectedImages.length) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (_pageController.hasClients) {
+        if (mounted && _pageController.hasClients) {
           _pageController.animateToPage(
             _currentImageIndex,
             duration: const Duration(milliseconds: 300),
@@ -225,6 +236,8 @@ class _PhotoUploadState extends State<PhotoUpload> {
   }
 
   void _pickProductImage() async {
+    if (!_canEdit) return;
+    final generation = _pickGeneration;
     final source = await showModalBottomSheet<ImageSource>(
       context: context,
       builder: (context) => SafeArea(
@@ -246,17 +259,17 @@ class _PhotoUploadState extends State<PhotoUpload> {
         ),
       ),
     );
-    if (source == null) return;
+    if (!_canEdit || generation != _pickGeneration || source == null) return;
     await pickImages(source);
   }
 
   void _openImageViewer(int initialIndex) {
-    if (selectedImages.isEmpty) return;
+    if (!_canEdit || selectedImages.isEmpty) return;
 
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => _PhotoViewerPage(
-          images: selectedImages,
+          images: List.of(selectedImages),
           initialIndex: initialIndex,
         ),
       ),
@@ -287,7 +300,7 @@ class _PhotoUploadState extends State<PhotoUpload> {
             itemCount: selectedImages.length,
             itemBuilder: (context, index) {
               return GestureDetector(
-                onTap: () => _openImageViewer(index),
+                onTap: widget.enabled ? () => _openImageViewer(index) : null,
                 child: Container(
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(20),
@@ -312,7 +325,7 @@ class _PhotoUploadState extends State<PhotoUpload> {
               ),
               child: IconButton(
                 icon: const Icon(Icons.close, color: Colors.white),
-                onPressed: () => _removeImage(_currentImageIndex),
+                onPressed: widget.enabled ? () => _removeImage(_currentImageIndex) : null,
               ),
             ),
           ),
@@ -328,7 +341,7 @@ class _PhotoUploadState extends State<PhotoUpload> {
               ),
               child: IconButton(
                 icon: const Icon(Icons.add_a_photo, color: Colors.white),
-                onPressed: _pickProductImage,
+                onPressed: widget.enabled ? _pickProductImage : null,
               ),
             ),
           ),
@@ -392,7 +405,7 @@ class _PhotoUploadState extends State<PhotoUpload> {
       color: AppColors.pinkBackground,
       borderRadius: BorderRadius.circular(20),
       child: InkWell(
-        onTap: _pickProductImage,
+        onTap: widget.enabled ? _pickProductImage : null,
         borderRadius: BorderRadius.circular(20),
         child: CustomPaint(
           painter: _DashedBorderPainter(

--- a/test/donation_submission_widgets_test.dart
+++ b/test/donation_submission_widgets_test.dart
@@ -1,0 +1,613 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:cherry_mvp/core/config/config.dart';
+import 'package:cherry_mvp/core/models/product.dart';
+import 'package:cherry_mvp/core/router/router.dart';
+import 'package:cherry_mvp/core/services/network/api_service.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/core/utils/status.dart';
+import 'package:cherry_mvp/features/auth/auth_view_model.dart';
+import 'package:cherry_mvp/features/categories/category_view_model.dart';
+import 'package:cherry_mvp/features/charity_page/charity_viewmodel.dart';
+import 'package:cherry_mvp/features/donation/donation_page.dart';
+import 'package:cherry_mvp/features/donation/donation_view_model.dart';
+import 'package:cherry_mvp/features/donation/models/donation_form_model.dart';
+import 'package:cherry_mvp/features/donation/postage_size_page.dart';
+import 'package:cherry_mvp/features/donation/successful_upload_page.dart';
+import 'package:cherry_mvp/features/donation/widgets/donation_form.dart';
+import 'package:cherry_mvp/features/donation/widgets/donation_form_field.dart';
+import 'package:cherry_mvp/features/donation/widgets/donation_dropdown_field.dart';
+import 'package:cherry_mvp/features/donation/widgets/photo_upload.dart';
+import 'package:cherry_mvp/features/donation/widgets/photo_tips_dialog.dart';
+import 'package:cherry_mvp/features/home/home_page.dart';
+import 'package:cherry_mvp/features/home/home_repository.dart';
+import 'package:cherry_mvp/features/home/home_viewmodel.dart';
+import 'package:cherry_mvp/features/liked_items/liked_items_page.dart';
+import 'package:cherry_mvp/features/products/product_repository.dart';
+import 'package:cherry_mvp/features/products/product_viewmodel.dart';
+import 'package:cherry_mvp/features/profile/profile_listings_repository.dart';
+import 'package:cherry_mvp/features/profile/profile_listings_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+import 'support/donation_test_support.dart';
+
+class _ApiStub extends Mock implements ApiService {}
+
+class _AuthStub extends Mock implements AuthViewModel {
+  @override
+  Future<void> loadCurrentUser() async {}
+}
+
+class _HomeStub implements IHomeRepository {
+  @override
+  Future<Result<ProductPage>> fetchProducts({int limit = 20, String? cursor, String? search}) async =>
+      Result.success(const ProductPage(products: [], limit: 20, nextCursor: null, hasMore: false));
+}
+
+class _ListingsStub implements IProfileListingsRepository {
+  @override
+  Future<Result<ProfileListingsPage>> fetchListings({int limit = 20, String? cursor}) async =>
+      Result.success(const ProfileListingsPage(listings: [], limit: 20, nextCursor: null, hasMore: false));
+}
+
+class _ProductsStub extends ProductRepository {
+  _ProductsStub() : super(_ApiStub());
+  @override
+  Future<Result<List<Product>>> fetchLikedProducts() async => Result.success([]);
+}
+
+class _RouteObserver extends NavigatorObserver {
+  final replacements = <Route<dynamic>>[];
+  final pushes = <Route<dynamic>>[];
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) => pushes.add(route);
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    if (oldRoute != null) replacements.add(oldRoute);
+  }
+}
+
+// Selector futures are independently controlled; submission navigation always uses real routes.
+class _Navigation extends NavigationProvider {
+  final selectors = <String, Completer<dynamic>>{};
+  @override
+  Future<dynamic> navigateTo(String routeName, {Object? arguments}) {
+    if (selectors.containsKey(routeName)) return selectors[routeName]!.future;
+    return super.navigateTo(routeName, arguments: arguments);
+  }
+}
+
+class _Harness {
+  final repository = ControlledDonationRepository();
+  final navigation = _Navigation();
+  final observer = _RouteObserver();
+  final toasts = <String>[];
+  late final viewModel = DonationViewModel(donationRepository: repository, navigator: navigation);
+  late CategoryViewModel categories;
+  late CharityViewModel charities;
+
+  Future<void> pump(WidgetTester tester, {Widget home = const HomePage()}) async {
+    tester.view.physicalSize = const Size(900, 1800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('PonnamKarthik/fluttertoast'),
+      (call) async {
+        if (call.method == 'showToast') toasts.add((call.arguments as Map)['msg'] as String);
+        return true;
+      },
+    );
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        const MethodChannel('PonnamKarthik/fluttertoast'),
+        null,
+      ),
+    );
+    categories = CategoryViewModel(categoryRepository: DonationCategoriesStub(), navigator: navigation);
+    charities = CharityViewModel(charityRepository: DonationCharitiesStub(), navigator: navigation);
+    final products = _ProductsStub();
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          Provider<NavigationProvider>.value(value: navigation),
+          ChangeNotifierProvider<DonationViewModel>.value(value: viewModel),
+          ChangeNotifierProvider<CategoryViewModel>.value(value: categories),
+          ChangeNotifierProvider<CharityViewModel>.value(value: charities),
+          ChangeNotifierProvider<AuthViewModel>.value(value: _AuthStub()),
+          ChangeNotifierProvider(create: (_) => SearchController()),
+          ChangeNotifierProvider(create: (_) => HomeViewModel(homeRepository: _HomeStub())),
+          ChangeNotifierProvider(create: (_) => ProfileListingsViewModel(repository: _ListingsStub())),
+          Provider<ProductRepository>.value(value: products),
+          ChangeNotifierProvider(
+            create: (_) => ProductViewModel(productRepository: products, navigator: navigation),
+          ),
+        ],
+        child: MaterialApp(
+          navigatorKey: navigation.navigatorKey,
+          navigatorObservers: [observer],
+          onGenerateRoute: AppRoutes.generateRoute,
+          home: home,
+        ),
+      ),
+    );
+    await settle(tester);
+  }
+
+  Future<void> open(WidgetTester tester, [String entry = 'Give']) async {
+    if (entry == 'Profile') {
+      await tester.tap(find.text('Profile'));
+      await settle(tester);
+      await tester.ensureVisible(find.text(AppStrings.profileListingsCreate));
+      await tester.tap(find.text(AppStrings.profileListingsCreate));
+    } else {
+      await tester.tap(find.text('Give'));
+    }
+    if (viewModel.isSubmitting) {
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+    } else {
+      await settle(tester);
+    }
+    expect(find.byType(DonationPage), findsOneWidget);
+  }
+
+  Future<void> fill(WidgetTester tester, {bool photos = true}) async {
+    await tester.enterText(find.widgetWithText(TextFormField, titleHintText), 'Wool jumper');
+    await tester.enterText(find.widgetWithText(TextFormField, descriptionHintText), 'Warm wool jumper');
+    await tester.enterText(find.widgetWithText(TextFormField, AppStrings.priceText), '12');
+    for (final selection in [
+      (AppStrings.categoryText, AppRoutes.category, testCategory),
+      (AppStrings.charityText, AppRoutes.charity, testCharity),
+      (postageSizeHintText, AppRoutes.postageSize, testPostage),
+    ]) {
+      navigation.selectors[selection.$2] = Completer<dynamic>();
+      await tester.ensureVisible(find.ancestor(of: find.text(selection.$1), matching: find.byType(InkWell)).first);
+      await tester.tap(find.ancestor(of: find.text(selection.$1), matching: find.byType(InkWell)).first);
+      navigation.selectors.remove(selection.$2)!.complete(selection.$3);
+      await settle(tester);
+    }
+    for (final selection in [('Quality', 'GOOD'), ('Size', 'Medium')]) {
+      final field = find.byWidgetPredicate(
+        (widget) => widget is DonationDropdownField && widget.formFieldsHintText == selection.$1,
+      );
+      await tester.ensureVisible(field);
+      await tester.tap(find.descendant(of: field, matching: find.byType(TextField)));
+      await settle(tester);
+      await tester.tap(find.text(selection.$2).last);
+      await settle(tester);
+    }
+    if (photos) {
+      tester.widget<PhotoUpload>(find.byType(PhotoUpload)).onImagesChanged!([XFile(photoPath)]);
+      await settle(tester);
+    }
+    await tester.ensureVisible(find.text(AppStrings.submitDonation));
+    await settle(tester);
+  }
+
+  Route<dynamic> formRoute(WidgetTester tester) => ModalRoute.of(tester.element(find.byType(DonationForm)))!;
+  Future<void> submit(WidgetTester tester) => tester.tap(find.text(AppStrings.submitDonation));
+}
+
+Future<void> settle(WidgetTester tester) async {
+  await tester.pumpAndSettle();
+  // Fluttertoast retains a one-second timer after its method-channel response.
+  await tester.pump(const Duration(seconds: 2));
+}
+
+late String photoPath;
+late String latePhotoPath;
+void main() {
+  setUpAll(() {
+    final directory = Directory.systemTemp.createTempSync('cherry-donation-photos-');
+    photoPath = '${directory.path}/photo.png';
+    // A real, local image fixture allows FileImage to render without picking or uploading photos.
+    final asset = Directory(
+      'assets/images',
+    ).listSync().whereType<File>().firstWhere((file) => file.path.endsWith('.png'));
+    asset.copySync(photoPath);
+    latePhotoPath = '${directory.path}/late-photo.png';
+    asset.copySync(latePhotoPath);
+    addTearDown(() => directory.deleteSync(recursive: true));
+  });
+
+  for (final entry in ['Give', 'Profile', 'Liked Items']) {
+    testWidgets('$entry replaces the submitted route exactly once and Back cannot reveal it', (tester) async {
+      final h = _Harness();
+      await h.pump(tester, home: entry == 'Liked Items' ? const LikedItemsPage() : const HomePage());
+      await h.open(tester, entry);
+      final route = h.formRoute(tester);
+      expect(route is DialogRoute, entry != 'Profile');
+      await h.fill(tester);
+      await h.submit(tester);
+      await h.submit(tester); // No rebuild between these taps.
+      expect(h.repository.requests, hasLength(1));
+      await tester.pump();
+      expect(h.viewModel.isSubmitting, isTrue);
+      h.repository.submissions.single.complete(Result.success(testDonationResponse()));
+      await settle(tester);
+      await h.categories.fetchCategories();
+      await h.charities.fetchCharities();
+      await settle(tester);
+      expect(find.byType(SuccessfulUploadPage), findsOneWidget);
+      expect(h.observer.replacements, [same(route)]);
+      expect(find.byType(DonationPage, skipOffstage: false), findsNothing);
+      expect(h.toasts, isEmpty);
+      await tester.binding.handlePopRoute();
+      await settle(tester);
+      expect(find.byType(SuccessfulUploadPage), findsNothing);
+      expect(find.byType(DonationPage, skipOffstage: false), findsNothing);
+      expect(find.byType(entry == 'Liked Items' ? LikedItemsPage : HomePage), findsOneWidget);
+    });
+  }
+
+  for (final throws in [false, true]) {
+    testWidgets('${throws ? 'unexpected exception' : 'failure'} retains the complete draft and permits one retry', (
+      tester,
+    ) async {
+      final h = _Harness();
+      await h.pump(tester);
+      await h.open(tester);
+      await h.fill(tester);
+      final originalImages = tester.widget<DonationForm>(find.byType(DonationForm)).selectedImages!;
+      await h.submit(tester);
+      await tester.pump();
+      expect(tester.widget<PhotoUpload>(find.byType(PhotoUpload)).enabled, isFalse);
+      expect(
+        tester
+            .widget<IconButton>(find.byWidgetPredicate((widget) => widget is IconButton && widget.tooltip == 'Close'))
+            .onPressed,
+        isNull,
+      );
+      expect(tester.widget<DonationFormField>(find.byType(DonationFormField).first).enabled, isFalse);
+      await tester.tap(find.byTooltip('Close'));
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+      expect(find.byType(DonationForm), findsOneWidget);
+      if (throws) {
+        h.repository.submissions.single.completeError(StateError('Private failure detail'));
+      } else {
+        h.repository.submissions.single.complete(Result.failure('Please try again'));
+      }
+      await settle(tester);
+      expect(h.toasts, [throws ? AppStrings.unexpectedErrorOccurred : 'Please try again']);
+      expect(tester.widget<DonationForm>(find.byType(DonationForm)).selectedImages, originalImages);
+      expect(tester.widget<PhotoUpload>(find.byType(PhotoUpload)).initialImages, originalImages);
+      expect(tester.widget<PhotoUpload>(find.byType(PhotoUpload)).enabled, isTrue);
+      expect(find.text('Wool jumper'), findsOneWidget);
+      expect(find.text('Warm wool jumper'), findsOneWidget);
+      expect(find.text('12'), findsOneWidget);
+      await h.submit(tester);
+      await h.submit(tester);
+      expect(h.repository.requests, hasLength(2));
+      expect(h.repository.requests.last.toJson(), h.repository.requests.first.toJson());
+      expect(h.repository.requests.last.localImages!.single.path, photoPath);
+      h.repository.submissions.last.complete(Result.success(testDonationResponse()));
+      await settle(tester);
+      expect(h.observer.replacements, hasLength(1));
+    });
+  }
+
+  testWidgets('Close, system Back and photo tips are blocked before a rebuild', (tester) async {
+    final h = _Harness();
+    await h.pump(tester);
+    await h.open(tester);
+    await h.fill(tester);
+    final tips = tester
+        .widget<InkWell>(find.ancestor(of: find.text(AppStrings.learnHow), matching: find.byType(InkWell)))
+        .onTap!;
+    final close = tester
+        .widget<IconButton>(find.byWidgetPredicate((widget) => widget is IconButton && widget.tooltip == 'Close'))
+        .onPressed!;
+    await h.submit(tester);
+    close();
+    tips();
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+    expect(find.byType(DonationForm), findsOneWidget);
+    expect(find.byType(PhotoTipsDialog), findsNothing);
+    h.repository.submissions.single.complete(Result.failure('Failed'));
+    await settle(tester);
+    await tester.tap(find.byTooltip('Close'));
+    await settle(tester);
+    expect(find.byType(DonationForm), findsNothing);
+  });
+
+  for (final success in [false, true]) {
+    testWidgets('forced disposal suppresses old ${success ? 'success' : 'failure'} and protects a reopened draft', (
+      tester,
+    ) async {
+      final h = _Harness();
+      await h.pump(tester);
+      await h.open(tester);
+      await h.fill(tester);
+      final route = h.formRoute(tester);
+      await h.submit(tester);
+      h.navigation.navigatorKey.currentState!.removeRoute(route);
+      await settle(tester);
+      await h.open(tester);
+      final newRoute = h.formRoute(tester);
+      expect(h.viewModel.isSubmitting, isTrue);
+      expect(await h.viewModel.submitDonation(testDonationRequest()), isNull);
+      h.repository.submissions.single.complete(
+        success ? Result.success(testDonationResponse()) : Result.failure('Old error'),
+      );
+      await settle(tester);
+      expect(h.formRoute(tester), same(newRoute));
+      expect(h.observer.replacements, isEmpty);
+      expect(h.toasts, isEmpty);
+      expect(find.byType(SuccessfulUploadPage), findsNothing);
+      await h.fill(tester);
+      expect(find.text('Wool jumper'), findsOneWidget);
+      await h.categories.fetchCategories();
+      await settle(tester);
+      expect(h.formRoute(tester), same(newRoute));
+      expect(h.repository.requests, hasLength(1));
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  testWidgets('completed success is not replayed when a new form opens', (tester) async {
+    final h = _Harness();
+    await h.pump(tester);
+    await h.open(tester);
+    await h.fill(tester);
+    await h.submit(tester);
+    h.repository.submissions.single.complete(Result.success(testDonationResponse()));
+    await settle(tester);
+    await tester.binding.handlePopRoute();
+    await settle(tester);
+    await h.open(tester);
+    await h.fill(tester);
+    await h.categories.fetchCategories();
+    await settle(tester);
+    expect(find.byType(DonationForm), findsOneWidget);
+    expect(find.text('Wool jumper'), findsOneWidget);
+    expect(h.observer.replacements, hasLength(1));
+    expect(h.viewModel.submissionStatus.type, StatusType.success);
+  });
+
+  for (final selector in [
+    (AppStrings.categoryText, AppRoutes.category, otherCategory),
+    (AppStrings.charityText, AppRoutes.charity, otherCharity),
+    (postageSizeHintText, AppRoutes.postageSize, otherPostage),
+  ]) {
+    testWidgets('late ${selector.$1} result is ignored during submission and after disposal', (tester) async {
+      final h = _Harness();
+      await h.pump(tester);
+      await h.open(tester);
+      await h.fill(tester);
+      final pending = Completer<dynamic>();
+      h.navigation.selectors[selector.$2] = pending;
+      await tester.ensureVisible(find.ancestor(of: find.text(selector.$1), matching: find.byType(InkWell)).first);
+      await tester.tap(find.ancestor(of: find.text(selector.$1), matching: find.byType(InkWell)).first);
+      await tester.ensureVisible(find.text(AppStrings.submitDonation));
+      await h.submit(tester);
+      await tester.pump();
+      pending.complete(selector.$3);
+      await tester.pump();
+      expect(h.repository.requests.single.postageSizeId, testPostage.id);
+      expect(tester.state<DonationFormState>(find.byType(DonationForm)).selectedCategoryId, testCategory.id);
+      expect(tester.state<DonationFormState>(find.byType(DonationForm)).selectedCharity, same(testCharity));
+      expect(tester.state<DonationFormState>(find.byType(DonationForm)).selectedPostageSize, same(testPostage));
+      expect(h.viewModel.isSubmitting, isTrue);
+      h.repository.submissions.single.complete(Result.failure('Failed'));
+      await settle(tester);
+      final late = Completer<dynamic>();
+      h.navigation.selectors[selector.$2] = late;
+      await tester.ensureVisible(find.ancestor(of: find.text(selector.$1), matching: find.byType(InkWell)).first);
+      await tester.tap(find.ancestor(of: find.text(selector.$1), matching: find.byType(InkWell)).first);
+      h.navigation.navigatorKey.currentState!.removeRoute(h.formRoute(tester));
+      await settle(tester);
+      late.complete(selector.$3);
+      await settle(tester);
+      expect(tester.takeException(), isNull);
+      expect(h.toasts, ['Failed']);
+    });
+  }
+
+  testWidgets('invalid fields and missing photos make zero requests', (tester) async {
+    final h = _Harness();
+    await h.pump(tester);
+    await h.open(tester);
+    await tester.ensureVisible(find.text(AppStrings.submitDonation));
+    await h.submit(tester);
+    await settle(tester);
+    expect(h.repository.requests, isEmpty);
+    await h.fill(tester, photos: false);
+    await h.submit(tester);
+    await settle(tester);
+    expect(h.repository.requests, isEmpty);
+    expect(h.toasts.last, AppStrings.pleaseAddPhoto);
+  });
+
+  testWidgets('postage page loads, retries, highlights the initial choice and returns a selection', (tester) async {
+    final h = _Harness();
+    await h.pump(tester);
+    final selection = h.navigation.navigateTo(AppRoutes.postageSize, arguments: {'initialPostageSize': otherPostage});
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.byType(PostageSizePage), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    h.repository.postageLoads.single.complete(Result.failure('Postage unavailable'));
+    await settle(tester);
+    expect(find.text('Postage unavailable'), findsOneWidget);
+    expect(find.text(AppStrings.retry), findsOneWidget);
+    await tester.tap(find.text(AppStrings.retry));
+    await tester.pump();
+    expect(h.repository.postageLoads, hasLength(2));
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    h.repository.postageLoads.last.complete(Result.success([testPostage, otherPostage]));
+    await settle(tester);
+    final selected = find.ancestor(of: find.text(otherPostage.description), matching: find.byType(Row)).first;
+    expect(find.descendant(of: selected, matching: find.byIcon(Icons.check_circle)), findsOneWidget);
+    final pending = h.viewModel.submitDonation(testDonationRequest());
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text(testPostage.description), findsOneWidget);
+    await tester.tap(find.text(testPostage.description));
+    expect(await selection, same(testPostage));
+    await settle(tester);
+    expect(h.viewModel.isSubmitting, isTrue);
+    h.repository.submissions.single.complete(Result.failure('Failed'));
+    await pending;
+  });
+
+  testWidgets('postage page exceptions show a controlled error and empty success remains usable', (tester) async {
+    final h = _Harness();
+    await h.pump(tester);
+    h.navigation.navigateTo(AppRoutes.postageSize);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    h.repository.postageLoads.single.completeError(StateError('Private details'));
+    await settle(tester);
+    expect(find.textContaining('Private details'), findsNothing);
+    expect(find.text(AppStrings.retry), findsOneWidget);
+    await tester.tap(find.text(AppStrings.retry));
+    await tester.pump();
+    h.repository.postageLoads.last.complete(Result.success([]));
+    await settle(tester);
+    expect(find.text(AppStrings.noPostageSizeInfosAvailable), findsOneWidget);
+    await tester.binding.handlePopRoute();
+    await settle(tester);
+    expect(find.byType(PostageSizePage), findsNothing);
+  });
+
+  testWidgets('postage notifications cannot complete or unlock the visible form', (tester) async {
+    final h = _Harness();
+    await h.pump(tester);
+    await h.open(tester);
+    await h.fill(tester);
+    await h.submit(tester);
+    await tester.pump();
+    for (final successful in [true, false]) {
+      final postage = h.viewModel.fetchPostageSizes();
+      h.repository.postageLoads.last.complete(
+        successful ? Result.success([otherPostage]) : Result.failure('Postage failed'),
+      );
+      await postage;
+      await tester.pump();
+      expect(h.viewModel.isSubmitting, isTrue);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(h.toasts, isEmpty);
+      expect(h.observer.replacements, isEmpty);
+      expect(h.repository.requests.single.postageSizeId, testPostage.id);
+      expect(tester.state<DonationFormState>(find.byType(DonationForm)).selectedPostageSize, same(testPostage));
+    }
+    h.repository.submissions.single.complete(Result.success(testDonationResponse()));
+    await settle(tester);
+    expect(h.observer.replacements, hasLength(1));
+  });
+
+  testWidgets('completion during a forced pop animation cannot navigate from the old form', (tester) async {
+    final h = _Harness();
+    await h.pump(tester);
+    await h.open(tester);
+    await h.fill(tester);
+    await h.submit(tester);
+    h.navigation.navigatorKey.currentState!.pop();
+    h.repository.submissions.single.complete(Result.success(testDonationResponse()));
+    await settle(tester);
+    expect(h.observer.replacements, isEmpty);
+    expect(h.toasts, isEmpty);
+    expect(find.byType(DonationPage, skipOffstage: false), findsNothing);
+    expect(find.byType(SuccessfulUploadPage), findsNothing);
+  });
+
+  for (final outcome in ['active', 'failed', 'disposed', 'picker exception']) {
+    testWidgets('late gallery result is safe when submission is $outcome', (tester) async {
+      final h = _Harness();
+      await h.pump(tester);
+      await h.open(tester);
+      await h.fill(tester);
+      final photoResult = Completer<List<String>>();
+      const channel = MethodChannel('plugins.flutter.io/image_picker');
+      var pickerCalls = 0;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, 'pickMultiImage');
+        pickerCalls++;
+        return photoResult.future;
+      });
+      addTearDown(() => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null));
+      await tester.ensureVisible(find.byIcon(Icons.add_a_photo));
+      await tester.tap(find.byIcon(Icons.add_a_photo));
+      await settle(tester);
+      await tester.tap(find.text(AppStrings.galleryPhotoMultiple));
+      await settle(tester);
+      expect(pickerCalls, 1);
+      await tester.ensureVisible(find.text(AppStrings.submitDonation));
+      await h.submit(tester);
+      await tester.pump();
+      if (outcome == 'failed') {
+        h.repository.submissions.single.complete(Result.failure('Failed'));
+        await settle(tester);
+      } else if (outcome == 'disposed' || outcome == 'picker exception') {
+        h.navigation.navigatorKey.currentState!.removeRoute(h.formRoute(tester));
+        await settle(tester);
+      }
+      if (outcome == 'picker exception') {
+        photoResult.completeError(PlatformException(code: 'unavailable'));
+      } else {
+        photoResult.complete([latePhotoPath]);
+      }
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+      if (outcome == 'active' || outcome == 'failed') {
+        expect(tester.widget<DonationForm>(find.byType(DonationForm)).selectedImages, hasLength(1));
+      }
+      expect(h.repository.requests.single.localImages, hasLength(1));
+      if (outcome != 'failed') {
+        h.repository.submissions.single.complete(Result.success(testDonationResponse()));
+        await settle(tester);
+      }
+      expect(tester.takeException(), isNull);
+      if (outcome == 'disposed' || outcome == 'picker exception') {
+        expect(h.observer.replacements, isEmpty);
+        expect(h.toasts, isEmpty);
+      }
+    });
+  }
+
+  for (final success in [false, true]) {
+    testWidgets('a covering route stays current after ${success ? 'success' : 'failure'}', (tester) async {
+      final h = _Harness();
+      await h.pump(tester);
+      await h.open(tester);
+      await h.fill(tester);
+      await h.submit(tester);
+      final original = h.formRoute(tester);
+      final covering = MaterialPageRoute<void>(builder: (_) => const Scaffold(body: Text('Newer page')));
+      h.navigation.navigatorKey.currentState!.push(covering);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+      h.repository.submissions.single.complete(
+        success ? Result.success(testDonationResponse()) : Result.failure('Failed'),
+      );
+      await settle(tester);
+      expect(covering.isCurrent, isTrue);
+      expect(find.text('Newer page'), findsOneWidget);
+      expect(h.toasts, isEmpty);
+      expect(h.observer.replacements, isEmpty);
+      expect(original.isActive, !success);
+      h.navigation.navigatorKey.currentState!.pop();
+      await settle(tester);
+      if (success) {
+        expect(find.byType(DonationForm, skipOffstage: false), findsNothing);
+      } else {
+        expect(find.byType(DonationForm), findsOneWidget);
+        expect(find.text('Wool jumper'), findsOneWidget);
+        expect(find.text(AppStrings.submitDonation), findsOneWidget);
+        await h.submit(tester);
+        expect(h.repository.requests, hasLength(2));
+        h.repository.submissions.last.complete(Result.success(testDonationResponse()));
+        await settle(tester);
+      }
+    });
+  }
+}

--- a/test/donation_view_model_test.dart
+++ b/test/donation_view_model_test.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+
+import 'package:cherry_mvp/core/config/app_strings.dart';
+import 'package:cherry_mvp/core/router/nav_provider.dart';
+import 'package:cherry_mvp/core/utils/donor_discount_state_store.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/core/utils/status.dart';
+import 'package:cherry_mvp/features/donation/donation_view_model.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'support/donation_test_support.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late ControlledDonationRepository repository;
+  late DonationViewModel viewModel;
+
+  setUp(() {
+    repository = ControlledDonationRepository();
+    viewModel = DonationViewModel(donationRepository: repository, navigator: NavigationProvider());
+  });
+
+  test('overlapping calls accept one request and give no result to the ignored caller', () async {
+    final first = viewModel.submitDonation(testDonationRequest());
+    final second = viewModel.submitDonation(testDonationRequest());
+    expect(repository.requests, hasLength(1));
+    expect(await second, isNull);
+    expect(viewModel.isSubmitting, isTrue);
+    repository.submissions.single.complete(Result.success(testDonationResponse()));
+    expect((await first)!.isSuccess, isTrue);
+    expect(viewModel.isSubmitting, isFalse);
+    expect(viewModel.submissionStatus.type, StatusType.success);
+  });
+
+  for (final outcome in ['success', 'failure', 'exception']) {
+    test('postage $outcome cannot alter or unlock an active submission', () async {
+      final pending = viewModel.submitDonation(testDonationRequest());
+      final postage = viewModel.fetchPostageSizes();
+      expect(viewModel.postageStatus.type, StatusType.loading);
+      expect(viewModel.submissionStatus.type, StatusType.loading);
+      switch (outcome) {
+        case 'success':
+          repository.postageLoads.single.complete(Result.success([testPostage]));
+        case 'failure':
+          repository.postageLoads.single.complete(Result.failure('Postage unavailable'));
+        case 'exception':
+          repository.postageLoads.single.completeError(StateError('Unexpected'));
+      }
+      await postage;
+      expect(viewModel.postageStatus.type, outcome == 'success' ? StatusType.success : StatusType.failure);
+      expect(viewModel.submissionStatus.type, StatusType.loading);
+      expect(viewModel.isSubmitting, isTrue);
+      expect(await viewModel.submitDonation(testDonationRequest()), isNull);
+      repository.submissions.single.complete(Result.failure('Try again'));
+      await pending;
+    });
+  }
+
+  for (final throws in [false, true]) {
+    test('${throws ? 'exception' : 'failure'} releases the lock for a deliberate retry', () async {
+      final first = viewModel.submitDonation(testDonationRequest());
+      if (throws) {
+        repository.submissions.single.completeError(StateError('Private exception detail'));
+      } else {
+        repository.submissions.single.complete(Result.failure('Could not submit'));
+      }
+      final result = (await first)!;
+      expect(result.isSuccess, isFalse);
+      expect(result.error, throws ? AppStrings.unexpectedErrorOccurred : 'Could not submit');
+      expect(viewModel.submissionStatus.type, StatusType.failure);
+      expect(viewModel.isSubmitting, isFalse);
+      final retry = viewModel.submitDonation(testDonationRequest());
+      expect(repository.requests, hasLength(2));
+      repository.submissions.last.complete(Result.success(testDonationResponse()));
+      expect((await retry)!.isSuccess, isTrue);
+    });
+  }
+
+  test('accepted requests own immutable copies of both image lists', () async {
+    final images = [XFile('photo.jpg')];
+    final urls = ['existing-image'];
+    final input = testDonationRequest(images: images, urls: urls);
+    final pending = viewModel.submitDonation(input);
+    images.clear();
+    urls.add('late-image');
+    final accepted = repository.requests.single;
+    expect(accepted.localImages!.single.path, 'photo.jpg');
+    expect(accepted.productImages, ['existing-image']);
+    expect(() => accepted.localImages!.clear(), throwsUnsupportedError);
+    expect(() => accepted.productImages!.clear(), throwsUnsupportedError);
+    expect(accepted.toJson(), testDonationRequest(urls: ['existing-image']).toJson());
+    repository.submissions.single.complete(Result.success(testDonationResponse()));
+    await pending;
+  });
+
+  test('disposing the view model does not notify after asynchronous completion', () async {
+    final pending = viewModel.submitDonation(testDonationRequest());
+    final postage = viewModel.fetchPostageSizes();
+    viewModel.dispose();
+    expect(await viewModel.submitDonation(testDonationRequest()), isNull);
+    repository.submissions.single.complete(Result.success(testDonationResponse()));
+    repository.postageLoads.single.complete(Result.success([testPostage]));
+    await Future.wait([pending, postage]);
+    expect(repository.requests, hasLength(1));
+  });
+
+  test('enabled donor-discount follow-up persists the captured value once', () async {
+    SharedPreferences.resetStatic();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/shared_preferences'),
+      (call) async => call.method == 'getAll' ? <String, Object>{} : true,
+    );
+    final pending = viewModel.submitDonation(testDonationRequest(), donorDiscountActive: true);
+    repository.submissions.single.complete(Result.success(testDonationResponse()));
+    expect((await pending)!.isSuccess, isTrue);
+    expect(await DonorDiscountStateStore.getDonorDiscountState('created-listing'), isTrue);
+  });
+
+  test('local persistence failure preserves success and keeps the lock until handled', () async {
+    SharedPreferences.resetStatic();
+    const channel = MethodChannel('plugins.flutter.io/shared_preferences');
+    final persistence = Completer<bool>();
+    var writes = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'getAll') return <String, Object>{};
+      writes++;
+      return persistence.future;
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+      SharedPreferences.resetStatic();
+    });
+    final pending = viewModel.submitDonation(testDonationRequest(), donorDiscountActive: false);
+    repository.submissions.single.complete(Result.success(testDonationResponse()));
+    await Future<void>.delayed(Duration.zero);
+    expect(viewModel.isSubmitting, isTrue);
+    expect(await viewModel.submitDonation(testDonationRequest()), isNull);
+    persistence.completeError(PlatformException(code: 'unavailable'));
+    expect((await pending)!.isSuccess, isTrue);
+    expect(writes, 1);
+    expect(viewModel.submissionStatus.type, StatusType.success);
+    expect(viewModel.isSubmitting, isFalse);
+  });
+}

--- a/test/support/donation_test_support.dart
+++ b/test/support/donation_test_support.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:cherry_mvp/core/models/category.dart';
+import 'package:cherry_mvp/core/models/product.dart';
+import 'package:cherry_mvp/core/utils/result.dart';
+import 'package:cherry_mvp/features/categories/category_repository.dart';
+import 'package:cherry_mvp/features/charity_page/charity_model.dart';
+import 'package:cherry_mvp/features/charity_page/charity_repository.dart';
+import 'package:cherry_mvp/features/donation/donation_repository.dart';
+import 'package:cherry_mvp/features/donation/models/donation_model.dart';
+import 'package:cherry_mvp/features/donation/models/postage_size_info.dart';
+import 'package:image_picker/image_picker.dart';
+
+class ControlledDonationRepository implements IDonationRepository {
+  final requests = <DonationRequest>[];
+  final submissions = <Completer<Result<DonationResponse>>>[];
+  final postageLoads = <Completer<Result<List<PostageSizeInfo>>>>[];
+
+  @override
+  Future<Result<DonationResponse>> submitDonation(DonationRequest request) {
+    requests.add(request);
+    final pending = Completer<Result<DonationResponse>>();
+    submissions.add(pending);
+    return pending.future;
+  }
+
+  @override
+  Future<Result<List<PostageSizeInfo>>> fetchPostageSizes() {
+    final pending = Completer<Result<List<PostageSizeInfo>>>();
+    postageLoads.add(pending);
+    return pending.future;
+  }
+}
+
+final testCategory = Category(
+  id: 'category-id',
+  name: 'Women',
+  imageUrl: '',
+  createdAt: DateTime(2025),
+  updatedAt: DateTime(2025),
+);
+final testCharity = Charity(
+  id: 'charity-id',
+  name: 'Test charity',
+  imageUrl: '',
+  createdAt: DateTime(2025),
+  updatedAt: DateTime(2025),
+);
+final testPostage = PostageSizeInfo(
+  id: 'postage-small',
+  type: 'inpost',
+  size: PostageSize.small,
+  description: 'Small parcel',
+  weight: 500,
+);
+final otherPostage = PostageSizeInfo(
+  id: 'postage-large',
+  type: 'inpost',
+  size: PostageSize.large,
+  description: 'Large parcel',
+  weight: 2000,
+);
+
+class DonationCategoriesStub implements ICategoryRepository {
+  @override
+  Future<Result<List<Category>>> fetchCategories() async => Result.success([testCategory]);
+}
+
+class DonationCharitiesStub implements ICharityRepository {
+  @override
+  Future<Result<List<Charity>>> fetchCharities() async => Result.success([testCharity]);
+}
+
+DonationRequest testDonationRequest({List<XFile>? images, List<String>? urls}) => DonationRequest(
+  name: 'Wool jumper',
+  description: 'Warm wool jumper',
+  categoryId: testCategory.id,
+  charityId: testCharity.id,
+  quality: 'GOOD',
+  size: 'Medium',
+  postageSizeId: testPostage.id,
+  donation: 12,
+  price: 12,
+  localImages: images,
+  productImages: urls,
+);
+
+DonationResponse testDonationResponse() => DonationResponse(
+  success: true,
+  message: 'Created',
+  data: Product(
+    id: 'created-listing',
+    name: 'Wool jumper',
+    description: 'Warm wool jumper',
+    quality: 'GOOD',
+    productImages: const [],
+    donation: 12,
+    price: 12,
+    securityFee: 1,
+    likes: 0,
+    number: 10,
+    size: 'Medium',
+    postageSizeId: testPostage.id,
+  ),
+);
+
+final otherCategory = Category(
+  id: 'other-category',
+  name: 'Men',
+  imageUrl: '',
+  createdAt: DateTime(2025),
+  updatedAt: DateTime(2025),
+);
+final otherCharity = Charity(
+  id: 'other-charity',
+  name: 'Another charity',
+  imageUrl: '',
+  createdAt: DateTime(2025),
+  updatedAt: DateTime(2025),
+);


### PR DESCRIPTION
## Summary

- Improve reliability across the donation listing submission flow, including form fields, dropdowns, postage size selection, photo upload, and submission state handling.
- Add safer logging through `safe_log.dart`.
- Refine donation page and view-model behaviour to reduce submission failures and improve error handling.
- Document the reliability QA approach in `docs/qa/listing-submission-reliability.md`.
- Add and update widget and view-model tests covering the affected submission flows.

## Testing

- Added or updated donation submission widget and view-model test coverage.
- Test execution results were not provided, so the full suite and manual UI behaviour remain to be verified.
- Reviewers should pay particular attention to validation, photo upload state, postage-size selection, and logging behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Donation submissions now complete through a single, reliable flow with success navigation occurring once.
  - Form fields, photo editing, closing, and photo tips are disabled while a submission is in progress.
  - Submission photos and form selections are preserved safely during navigation and asynchronous updates.
  - Postage options now load and display independently from donation submission status.

- **Bug Fixes**
  - Prevented duplicate submissions and stale image, selector, or postage updates.
  - Failed submissions retain the completed draft and allow users to retry.
  - Improved handling of submission completion when the page is closed or navigated away from.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->